### PR TITLE
Update requires-python version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name="Clarissa A. Seidler", email="clarissa.seidler@gmail.com" },
 ]
 description = "PQAnalysis is a python package for the analysis of PQ simulations."
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Installation with python 3.11.5 failed due to `SyntaxError`:

```
$ build_nep_traj
Traceback (most recent call last):
  File "/home/jog/projects/PQAnalysis/venv/bin/build_nep_traj", line 5, in <module>
    from PQAnalysis.cli.build_nep_traj import main
  File "/home/jog/projects/PQAnalysis/venv/lib/python3.11/site-packages/PQAnalysis/__init__.py", line 26
    f"Invalid logging level: {logging_env_var}. Valid logging levels are: {
    ^
SyntaxError: unterminated string literal (detected at line 26)
```

The `requires-python` keyword should definitely be changed to 3.12. Before that version of python there were definite more limitations.