### PR TITLE
Feature/shake gen comments

### DIFF
--- a/PQAnalysis/topology/shake_topology.py
+++ b/PQAnalysis/topology/shake_topology.py
@@ -135,11 +135,11 @@ class ShakeTopologyGenerator:
                     exception=PQValueError
                 )
 
-            self.line_comments = []
+            self.line_comments = [""] * len(self.indices)
 
             for i, equivalent_indices in enumerate(indices):
                 for _ in equivalent_indices:
-                    self.line_comments.append(comments[i])
+                    self.line_comments[equivalent_indices[i]] = comments[i]
 
     @runtime_type_checking
     def write_topology(

--- a/PQAnalysis/topology/shake_topology.py
+++ b/PQAnalysis/topology/shake_topology.py
@@ -118,7 +118,7 @@ class ShakeTopologyGenerator:
         indices : List[Np1DIntArray] | Np2DIntArray
             The indices of the equivalent atoms.
         comments : List[str], optional
-            The comments for the topology, by default None
+            The line comments for the averaged distances, by default None
         """
 
         for equivalent_indices in indices:
@@ -144,6 +144,29 @@ class ShakeTopologyGenerator:
 
                 for index in _indices:
                     self.line_comments[index] = comments[i]
+
+    @runtime_type_checking
+    def add_comments(self, comments: List[str]) -> None:
+        """
+        Adds comments to the topology.
+
+        Parameters
+        ----------
+        comments : List[str]
+            The comments to add to each line of the shake topology.
+        """
+
+        if len(comments) != len(self.indices):
+            self.logger.error(
+                "The number of comments does not match the number of indices.",
+                exception=PQValueError
+            )
+
+        if self.line_comments is None:
+            self.line_comments = [""] * len(self.indices)
+
+        for i, comment in enumerate(comments):
+            self.line_comments[i] = comment
 
     @runtime_type_checking
     def write_topology(

--- a/PQAnalysis/topology/shake_topology.py
+++ b/PQAnalysis/topology/shake_topology.py
@@ -138,8 +138,12 @@ class ShakeTopologyGenerator:
             self.line_comments = [""] * len(self.indices)
 
             for i, equivalent_indices in enumerate(indices):
-                for _ in equivalent_indices:
-                    self.line_comments[equivalent_indices[i]] = comments[i]
+                _indices = np.nonzero(
+                    np.in1d(self.indices, equivalent_indices)
+                )[0]
+
+                for index in _indices:
+                    self.line_comments[index] = comments[i]
 
     @runtime_type_checking
     def write_topology(

--- a/PQAnalysis/topology/shake_topology.py
+++ b/PQAnalysis/topology/shake_topology.py
@@ -156,7 +156,7 @@ class ShakeTopologyGenerator:
             The comments to add to each line of the shake topology.
         """
 
-        if len(comments) != len(self.indices):
+        if self.indices is None or len(comments) != len(self.indices):
             self.logger.error(
                 "The number of comments does not match the number of indices.",
                 exception=PQValueError

--- a/tests/topology/test_shakeTopology.py
+++ b/tests/topology/test_shakeTopology.py
@@ -1,11 +1,15 @@
+import pytest
 import numpy as np
-
-from . import pytestmark
 
 from PQAnalysis.topology.shake_topology import ShakeTopologyGenerator
 from PQAnalysis.core import Atom
 from PQAnalysis.atomic_system import AtomicSystem
 from PQAnalysis.traj import Trajectory
+from PQAnalysis.exceptions import PQValueError
+
+from . import pytestmark  # pylint: disable=unused-import
+
+#pylint: disable=protected-access
 
 
 
@@ -31,38 +35,10 @@ class TestShakeTopologyGenerator:
     def test_generate_topology(self):
         atoms = [Atom('C'), Atom('H'), Atom('H'), Atom('O'), Atom('H')]
         pos = np.array(
-            [[0.1,
-            0,
-            0],
-            [1,
-            0,
-            0],
-            [2.1,
-            0,
-            0],
-            [3,
-            0,
-            0],
-            [4,
-            0,
-            0]]
+            [[0.1, 0, 0], [1, 0, 0], [2.1, 0, 0], [3, 0, 0], [4, 0, 0]]
         )
         pos2 = np.array(
-            [[0.5,
-            0,
-            0],
-            [1,
-            0.5,
-            0],
-            [2.5,
-            0,
-            0],
-            [3,
-            0.5,
-            0],
-            [4.5,
-            0,
-            0]]
+            [[0.5, 0, 0], [1, 0.5, 0], [2.5, 0, 0], [3, 0.5, 0], [4.5, 0, 0]]
         )
         system = AtomicSystem(pos=pos, atoms=atoms)
         system2 = AtomicSystem(pos=pos2, atoms=atoms)
@@ -80,39 +56,11 @@ class TestShakeTopologyGenerator:
     def test_average_equivalents(self):
         atoms = [Atom('C'), Atom('H'), Atom('H'), Atom('O'), Atom('H')]
         pos = np.array(
-            [[0.1,
-            0,
-            0],
-            [1,
-            0,
-            0],
-            [2.1,
-            0,
-            0],
-            [3,
-            0,
-            0],
-            [4,
-            0,
-            0]]
+            [[0.1, 0, 0], [1, 0, 0], [2.1, 0, 0], [3, 0, 0], [4, 0, 0]]
         )
 
         pos2 = np.array(
-            [[0.5,
-            0,
-            0],
-            [1,
-            0.5,
-            0],
-            [2.5,
-            0,
-            0],
-            [3,
-            0.5,
-            0],
-            [4.5,
-            0,
-            0]]
+            [[0.5, 0, 0], [1, 0.5, 0], [2.5, 0, 0], [3, 0.5, 0], [4.5, 0, 0]]
         )
 
         system = AtomicSystem(pos=pos, atoms=atoms)
@@ -129,43 +77,41 @@ class TestShakeTopologyGenerator:
         assert np.allclose(indices, [1, 2, 4])
         assert np.allclose(target_indices, [0, 3, 3])
         assert np.allclose(distances, [0.80355339, 1.047061405, 1.047061405])
+        assert generator.line_comments is None
+
+        generator.average_equivalents(
+            [np.array([1]), np.array([2, 4])],
+            comments=['test', 'test2'],
+        )
+        assert generator.line_comments == ['test', 'test2', 'test2']
+
+    def test_add_comments(self):
+        generator = ShakeTopologyGenerator()
+        with pytest.raises(PQValueError) as exception:
+            generator.add_comments(['test', 'test2'])
+        assert str(
+            exception.value
+        ) == "The number of comments does not match the number of indices."
+
+        generator.indices = np.array([1, 2, 3])
+
+        with pytest.raises(PQValueError) as exception:
+            generator.add_comments(['test', 'test2'])
+        assert str(
+            exception.value
+        ) == "The number of comments does not match the number of indices."
+
+        generator.add_comments(['test', 'test2', 'test3'])
+        assert generator.line_comments == ['test', 'test2', 'test3']
 
     def test_write_topology(self, capsys):
         atoms = [Atom('C'), Atom('H'), Atom('H'), Atom('O'), Atom('H')]
         pos = np.array(
-            [[0.1,
-            0,
-            0],
-            [1,
-            0,
-            0],
-            [2.1,
-            0,
-            0],
-            [3,
-            0,
-            0],
-            [4,
-            0,
-            0]]
+            [[0.1, 0, 0], [1, 0, 0], [2.1, 0, 0], [3, 0, 0], [4, 0, 0]]
         )
 
         pos2 = np.array(
-            [[0.5,
-            0,
-            0],
-            [1,
-            0.5,
-            0],
-            [2.5,
-            0,
-            0],
-            [3,
-            0.5,
-            0],
-            [4.5,
-            0,
-            0]]
+            [[0.5, 0, 0], [1, 0.5, 0], [2.5, 0, 0], [3, 0.5, 0], [4.5, 0, 0]]
         )
 
         system = AtomicSystem(pos=pos, atoms=atoms)
@@ -185,5 +131,36 @@ SHAKE 3  2  0
 2 1 0.8035533905932738
 3 4 0.8035533905932737
 5 4 1.290569415042095
+END
+"""
+
+        print()
+
+        generator.add_comments(['test', 'test2', 'test3'])
+        generator.write_topology()
+
+        captured = capsys.readouterr()
+        assert captured.out == """
+SHAKE 3  2  0
+2 1 0.8035533905932738  # test
+3 4 0.8035533905932737  # test2
+5 4 1.290569415042095  # test3
+END
+"""
+
+        print()
+
+        generator.average_equivalents(
+            [np.array([1]), np.array([2, 4])],
+            comments=['test', 'test2'],
+        )
+        generator.write_topology()
+
+        captured = capsys.readouterr()
+        assert captured.out == """
+SHAKE 3  2  0
+2 1 0.8035533905932738  # test
+3 4 1.0470614028176843  # test2
+5 4 1.0470614028176843  # test2
 END
 """


### PR DESCRIPTION
Added possibility to complement shake topology generation with line comments for each shaked bond.

This includes two main approach:

1) add comments to function `generate_equivalents` for each distinct shake bond

2) `add_comment` function to explicitly add line comments for each of the shaked bonds

closes #71 