### PR TITLE
Feature/xyz reader performance

### DIFF
--- a/PQAnalysis/io/traj_file/frame_reader.py
+++ b/PQAnalysis/io/traj_file/frame_reader.py
@@ -251,7 +251,9 @@ class _FrameReader:
         return value, atoms
 
     def _get_topology(
-        self, atoms: List[str], topology: Topology | None
+        self,
+        atoms: List[str],
+        topology: Topology | None,
     ) -> Topology:
         """
         Returns the topology of the frame.

--- a/PQAnalysis/io/traj_file/trajectory_reader.py
+++ b/PQAnalysis/io/traj_file/trajectory_reader.py
@@ -251,7 +251,7 @@ class TrajectoryReader(BaseReader):
                             # then increment the frame index
                             frame_index += 1
 
-                            if self.constant_topology and self.topology is not None:
+                            if self.constant_topology and self.topology is None:
                                 self.topology = frame.topology
 
                         frame_lines = [line]
@@ -278,7 +278,7 @@ class TrajectoryReader(BaseReader):
                     # then increment the frame index
                     frame_index += 1
 
-                if self.constant_topology and self.topology is not None:
+                if self.constant_topology and self.topology is None:
                     self.topology = frame.topology
 
     @runtime_type_checking


### PR DESCRIPTION
Found a small error in lodical expressions when reading trajectory files.

Actually it is not an error, some time ago I implemented a constant topology approach for reading files to speed up things. Actually there were to `is not None`, which should have been `is None` and therefore also the constant topology approach was treated as it should build a new topology for each frame.

PERFORMANCE SPEEDUP > 12.0 = 1200%