### PR TITLE
feat: support multiple energy files

### DIFF
--- a/PQAnalysis/io/energy_file_reader.py
+++ b/PQAnalysis/io/energy_file_reader.py
@@ -30,7 +30,7 @@ class EnergyFileReader(BaseReader):
     @runtime_type_checking
     def __init__(
         self,
-        filename: str,
+        filename: str | list[str],
         info_filename: str | None = None,
         use_info_file: bool = True,
         engine_format: MDEngineFormat | str = MDEngineFormat.PQ
@@ -58,8 +58,9 @@ class EnergyFileReader(BaseReader):
 
         Parameters
         ----------
-        filename : str
-            The name of the file to read from.
+        filename : str or list of str
+            The name of the file to read from or a list of filenames to read
+            from.
         info_filename : str, optional
             The name of the info file to read from, by default None
         use_info_file : bool, optional
@@ -103,10 +104,21 @@ class EnergyFileReader(BaseReader):
 
             info, units = reader.read()
 
-        with open(self.filename, "r", encoding='utf-8') as file:
+        data = []
 
-            data = []
+        for filename in self._filenames_to_read():
+            data.extend(self._read_data_from_file(filename))
 
+        return Energy(np.array(data).T, info, units)
+
+    @staticmethod
+    def _read_data_from_file(filename: str) -> list[list[float]]:
+        """
+        Reads energy data from a single file.
+        """
+        data = []
+
+        with open(filename, "r", encoding='utf-8') as file:
             for line in file:
                 if line.startswith("#"):
                     continue
@@ -114,7 +126,16 @@ class EnergyFileReader(BaseReader):
                 data_line = [float(x) for x in line.split()]
                 data.append(list(data_line))
 
-        return Energy(np.array(data).T, info, units)
+        return data
+
+    def _filenames_to_read(self) -> list[str]:
+        """
+        Gets the energy filenames to read.
+        """
+        if self.multiple_files:
+            return self.filenames
+
+        return [self.filename]
 
     def __info_file_found__(self) -> bool:
         """
@@ -137,7 +158,9 @@ class EnergyFileReader(BaseReader):
         """
         if self.info_filename is None:
 
-            self.info_filename = os.path.splitext(self.filename)[0] + ".info"
+            self.info_filename = os.path.splitext(
+                self._filenames_to_read()[0]
+            )[0] + ".info"
 
             try:
                 BaseReader(self.info_filename)

--- a/tests/io/test_energyFileReader.py
+++ b/tests/io/test_energyFileReader.py
@@ -20,20 +20,36 @@ class TestEnergyReader:
             EnergyFileReader("tmp")
         assert str(exception.value) == "File tmp not found."
 
+        with pytest.raises(PQFileNotFoundError) as exception:
+            EnergyFileReader(["md-01.en", "tmp"])
+        assert str(exception.value) == (
+            "At least one of the given files does not exist. File tmp not found."
+        )
+
         reader = EnergyFileReader("md-01.en")
         assert reader.filename == "md-01.en"
+        assert reader.multiple_files == False
+        assert reader.info_filename == "md-01.info"
+        assert reader.with_info_file == True
+        assert reader.format == MDEngineFormat.PQ
+
+        reader = EnergyFileReader(["md-01.en", "md-01_noinfo.en"])
+        assert reader.filenames == ["md-01.en", "md-01_noinfo.en"]
+        assert reader.multiple_files == True
         assert reader.info_filename == "md-01.info"
         assert reader.with_info_file == True
         assert reader.format == MDEngineFormat.PQ
 
         reader = EnergyFileReader("md-01.en", use_info_file=False)
         assert reader.filename == "md-01.en"
+        assert reader.multiple_files == False
         assert reader.info_filename == None
         assert reader.with_info_file == False
         assert reader.format == MDEngineFormat.PQ
 
         reader = EnergyFileReader("md-01_noinfo.en")
         assert reader.filename == "md-01_noinfo.en"
+        assert reader.multiple_files == False
         assert reader.info_filename == None
         assert reader.with_info_file == False
         assert reader.format == MDEngineFormat.PQ
@@ -140,6 +156,27 @@ class TestEnergyReader:
         reader = EnergyFileReader("md-01_noinfo.en")
         energy = reader.read()
         assert np.allclose(energy.data, data_ref)
+        assert energy.info == defaultdict(lambda: None)
+        assert energy.units == defaultdict(lambda: None)
+        assert energy.info_given == False
+        assert energy.units_given == False
+
+        reader = EnergyFileReader(["md-01.en", "md-01.en"])
+        energy = reader.read()
+        assert energy.data.shape == (12, 4)
+        assert np.allclose(energy.data, np.hstack([data_ref, data_ref]))
+        assert energy.info == info
+        assert energy.units == units
+        assert energy.info_given == True
+        assert energy.units_given == True
+
+        reader = EnergyFileReader(
+            ["md-01_noinfo.en", "md-01_noinfo.en"],
+            use_info_file=False,
+        )
+        energy = reader.read()
+        assert energy.data.shape == (12, 4)
+        assert np.allclose(energy.data, np.hstack([data_ref, data_ref]))
         assert energy.info == defaultdict(lambda: None)
         assert energy.units == defaultdict(lambda: None)
         assert energy.info_given == False


### PR DESCRIPTION
Summary:
- Allow EnergyFileReader to accept a list of energy files.
- Concatenate energy rows in input-file order.
- Add coverage for list input with and without info files.

Resolves #112.