### PR TITLE
fix: preserve atom label case in gen conversions

### DIFF
--- a/PQAnalysis/io/gen_file/gen_file_reader.py
+++ b/PQAnalysis/io/gen_file/gen_file_reader.py
@@ -11,6 +11,7 @@ from beartype.typing import List, Tuple
 from PQAnalysis.io.base import BaseReader
 from PQAnalysis.types import PositiveInt, Np2DNumberArray, Np1DIntArray
 from PQAnalysis.core import Cell, Atom
+from PQAnalysis.core.atom.element import atomicNumbers as ATOMIC_NUMBERS
 from PQAnalysis.atomic_system import AtomicSystem
 from PQAnalysis.utils.custom_logging import setup_logger
 from PQAnalysis import __package_name__
@@ -58,13 +59,24 @@ class GenFileReader(BaseReader):
 
             coords, ids = self._read_coords(lines[2:2 + self.n_atoms])
 
+            cell_start = 2 + self.n_atoms
             cell = self._read_cell(
-                lines[2 + self.n_atoms:2 + self.n_atoms + 3]
+                lines[cell_start:cell_start + 4]
             ) if is_periodic else Cell()
 
-            atoms = [Atom(atom_names[id - 1]) for id in ids]
+            atoms = [self._read_atom(atom_names[id - 1]) for id in ids]
 
             return AtomicSystem(atoms=atoms, pos=coords, cell=cell)
+
+    @staticmethod
+    def _read_atom(atom_name: str) -> Atom:
+        """
+        Reads a gen atom name, preserving custom labels if needed.
+        """
+        if atom_name.lower() in ATOMIC_NUMBERS:
+            return Atom(atom_name)
+
+        return Atom(atom_name, use_guess_element=False)
 
     def _read_header(self,
                      header: List[str]) -> Tuple[PositiveInt, bool, List[str]]:
@@ -105,7 +117,7 @@ class GenFileReader(BaseReader):
                 exception=GenFileReaderError
             )
 
-        atom_names = [name.lower() for name in header[1].split()]
+        atom_names = header[1].split()
 
         return n_atoms, is_periodic, atom_names
 
@@ -140,7 +152,8 @@ class GenFileReader(BaseReader):
         """
         Reads the cell block of the gen file.
 
-        The cell block contains the box matrix in row-major order.
+        The cell block contains an origin line followed by the box matrix in
+        row-major order.
 
         Parameters
         ----------
@@ -152,8 +165,10 @@ class GenFileReader(BaseReader):
         Cell
             The cell object.
         """
+        box_lines = lines[1:] if len(lines) == 4 else lines
+
         box_matrix = np.zeros((3, 3))
-        for i, line in enumerate(lines):
+        for i, line in enumerate(box_lines):
             box_matrix[i] = np.array(line.split(), dtype=float)
 
         # NOTE: The box matrix is stored in row-major order

--- a/PQAnalysis/io/gen_file/gen_file_writer.py
+++ b/PQAnalysis/io/gen_file/gen_file_writer.py
@@ -108,9 +108,9 @@ class GenFileWriter(BaseWriter):
         """
         print(self.system.n_atoms, periodicity, file=self.file)
 
-        element_names = self.system.unique_element_names
+        atom_names = self._unique_atom_names()
 
-        print(" ".join(element_names), file=self.file)
+        print(" ".join(atom_names), file=self.file)
 
     def _write_coords(self) -> None:
         """
@@ -123,17 +123,34 @@ class GenFileWriter(BaseWriter):
         - The y-coordinate
         - The z-coordinate
         """
-        element_names = self.system.unique_element_names
+        atom_names = self._unique_atom_names()
+        atom_indices = {
+            atom_name: index
+            for index, atom_name in enumerate(atom_names, start=1)
+        }
+
         for i in range(self.system.n_atoms):
             print(
                 "\t",
                 i + 1,
-                element_names.index(self.system.atoms[i].element_name) + 1,
+                atom_indices[self.system.atoms[i].name],
                 self.system.pos[i, 0],
                 self.system.pos[i, 1],
                 self.system.pos[i, 2],
                 file=self.file
             )
+
+    def _unique_atom_names(self) -> list[str]:
+        """
+        Gets atom names in first-seen order.
+        """
+        atom_names = []
+
+        for atom in self.system.atoms:
+            if atom.name not in atom_names:
+                atom_names.append(atom.name)
+
+        return atom_names
 
     def _write_box_matrix(self) -> None:
         """

--- a/tests/io/test_genFile.py
+++ b/tests/io/test_genFile.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+
+from PQAnalysis.atomic_system import AtomicSystem
+from PQAnalysis.core import Atom
+from PQAnalysis.io import gen2xyz, read_gen_file, write_gen_file, xyz2gen
+
+from . import pytestmark  # pylint: disable=unused-import
+
+
+
+class TestGenFileConversion:
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_xyz2gen_preserves_atom_name_case(self):
+        with open("input.xyz", "w", encoding="utf-8") as file:
+            print("3", file=file)
+            print("", file=file)
+            print("C 0.0 0.0 0.0", file=file)
+            print("Cl 1.0 0.0 0.0", file=file)
+            print("Br 0.0 1.0 0.0", file=file)
+
+        xyz2gen("input.xyz", output="output.gen")
+
+        with open("output.gen", "r", encoding="utf-8") as file:
+            lines = file.read().splitlines()
+
+        assert lines[0] == "3 C"
+        assert lines[1] == "C Cl Br"
+        assert [line.split()[1] for line in lines[2:]] == ["1", "2", "3"]
+
+        system = read_gen_file("output.gen")
+        assert [atom.name for atom in system.atoms] == ["C", "Cl", "Br"]
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_write_gen_uses_atom_names_for_repeated_elements(self):
+        atoms = [Atom("C1", "C"), Atom("C2", "C"), Atom("C1", "C")]
+        system = AtomicSystem(
+            atoms=atoms,
+            pos=np.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                ]
+            ),
+        )
+
+        write_gen_file(system, "output.gen", periodic=False)
+
+        with open("output.gen", "r", encoding="utf-8") as file:
+            lines = file.read().splitlines()
+
+        assert lines[1] == "C1 C2"
+        assert [line.split()[1] for line in lines[2:]] == ["1", "2", "1"]
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_xyz2gen2xyz_preserves_periodic_pq_atom_labels(self):
+        with open("input.xyz", "w", encoding="utf-8") as file:
+            print("2 10.0 11.0 12.0 90.0 90.0 90.0", file=file)
+            print("", file=file)
+            print("C1 0.0 0.0 0.0", file=file)
+            print("C2 1.0 0.0 0.0", file=file)
+
+        xyz2gen("input.xyz", output="output.gen")
+        gen2xyz("output.gen", output="output.xyz")
+
+        with open("output.xyz", "r", encoding="utf-8") as file:
+            lines = file.read().splitlines()
+
+        header = lines[0].split()
+        assert header[0] == "2"
+        assert np.allclose([float(value) for value in header[1:]], [
+            10.0,
+            11.0,
+            12.0,
+            90.0,
+            90.0,
+            90.0,
+        ])
+        assert [line.split()[0] for line in lines[2:]] == ["C1", "C2"]
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_gen2xyz_preserves_atom_name_case(self):
+        with open("input.gen", "w", encoding="utf-8") as file:
+            print("3 C", file=file)
+            print("C Cl Br", file=file)
+            print("1 1 0.0 0.0 0.0", file=file)
+            print("2 2 1.0 0.0 0.0", file=file)
+            print("3 3 0.0 1.0 0.0", file=file)
+
+        gen2xyz("input.gen", output="output.xyz")
+
+        with open("output.xyz", "r", encoding="utf-8") as file:
+            lines = file.read().splitlines()
+
+        assert [line.split()[0] for line in lines[2:]] == ["C", "Cl", "Br"]


### PR DESCRIPTION
Summary:
- Preserve GEN header atom label case when reading GEN files.
- Write GEN species labels from atom names in first-seen order.
- Add coverage for xyz2gen and gen2xyz case preservation.

Resolves #105.