### PR TITLE
feat: add simulation time utility

### DIFF
--- a/PQAnalysis/utils/__init__.py
+++ b/PQAnalysis/utils/__init__.py
@@ -4,3 +4,4 @@ A package containing classes and functions with common use.
 
 from .common import print_header, __header__
 from .decorators import count_decorator, instance_function_count_decorator, timeit_in_class
+from .units import calculate_simulation_time

--- a/PQAnalysis/utils/units.py
+++ b/PQAnalysis/utils/units.py
@@ -1,6 +1,10 @@
 """
-A module containing different units related to the unum subpackage.
+A module containing different unit conversions and constants.
 """
+
+from numbers import Real
+
+from PQAnalysis.exceptions import PQValueError
 
 mol = 6.02214076e23  # pylint: disable=invalid-name
 
@@ -10,3 +14,50 @@ cal = J / 4.184  # pylint: disable=invalid-name
 kcal = cal / 1000.0  # pylint: disable=invalid-name
 eV = 6.241506363094e18 * J  # pylint: disable=invalid-name
 kcal_per_mol = kcal * mol  # pylint: disable=invalid-name
+
+
+def calculate_simulation_time(
+    timesteps: Real,
+    timestep_fs: Real,
+    unit: str = "ps",
+) -> float:
+    """
+    Calculates simulation time from a timestep count.
+
+    Parameters
+    ----------
+    timesteps : Real
+        The number of timesteps.
+    timestep_fs : Real
+        The timestep size in femtoseconds.
+    unit : str, optional
+        The output unit. Supported values are ``"fs"`` and ``"ps"``, by
+        default ``"ps"``.
+
+    Returns
+    -------
+    float
+        The simulation time in the requested unit.
+
+    Raises
+    ------
+    PQValueError
+        If timesteps or timestep_fs are negative, or if unit is unsupported.
+    """
+    if timesteps < 0:
+        raise PQValueError("timesteps has to be greater than or equal to 0.")
+
+    if timestep_fs < 0:
+        raise PQValueError("timestep_fs has to be greater than or equal to 0.")
+
+    time_fs = float(timesteps * timestep_fs)
+
+    if unit.lower() == "fs":
+        return time_fs
+
+    if unit.lower() == "ps":
+        return time_fs / 1000.0
+
+    raise PQValueError(
+        f"Unsupported time unit {unit}. Supported units are fs and ps."
+    )

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -1,0 +1,37 @@
+import pytest
+
+from PQAnalysis.exceptions import PQValueError
+from PQAnalysis.utils import calculate_simulation_time
+from PQAnalysis.utils.units import calculate_simulation_time as calculate_time
+
+from . import pytestmark  # pylint: disable=unused-import
+
+
+
+def test_calculate_simulation_time():
+    assert calculate_simulation_time(10000, 0.5) == 5.0
+    assert calculate_simulation_time(10000, 0.5, unit="ps") == 5.0
+    assert calculate_simulation_time(10000, 0.5, unit="fs") == 5000.0
+    assert calculate_simulation_time(10000, 0.5, unit="PS") == 5.0
+    assert calculate_simulation_time(0, 0.5) == 0.0
+    assert calculate_time(250, 2.0, unit="fs") == 500.0
+
+
+def test_calculate_simulation_time_raises_for_invalid_input():
+    with pytest.raises(PQValueError) as exception:
+        calculate_simulation_time(-1, 0.5)
+    assert str(exception.value) == (
+        "timesteps has to be greater than or equal to 0."
+    )
+
+    with pytest.raises(PQValueError) as exception:
+        calculate_simulation_time(1, -0.5)
+    assert str(exception.value) == (
+        "timestep_fs has to be greater than or equal to 0."
+    )
+
+    with pytest.raises(PQValueError) as exception:
+        calculate_simulation_time(1, 0.5, unit="ns")
+    assert str(exception.value) == (
+        "Unsupported time unit ns. Supported units are fs and ps."
+    )


### PR DESCRIPTION
Summary:
- Add a utility to calculate simulation time from timestep count and timestep size.
- Support fs and ps output.
- Add unit tests for conversion and validation behavior.
- Needed for PQEnalyzer

Resolves #9.