### PR TITLE
feat: add box file reader

### DIFF
--- a/PQAnalysis/io/__init__.py
+++ b/PQAnalysis/io/__init__.py
@@ -45,6 +45,7 @@ from .topology_file.api import read_topology_file, write_topology_file
 
 from .info_file_reader import InfoFileReader
 from .energy_file_reader import EnergyFileReader
+from .box_reader import BoxReader, read_box
 from .box_writer import BoxWriter
 
 from .input_file_reader import InputFileParser

--- a/PQAnalysis/io/box_reader.py
+++ b/PQAnalysis/io/box_reader.py
@@ -1,0 +1,111 @@
+"""
+A module containing the BoxReader class and its associated methods.
+"""
+
+import logging
+
+import numpy as np
+
+from PQAnalysis.io.base import BaseReader
+from PQAnalysis.utils.custom_logging import setup_logger
+from PQAnalysis import __package_name__
+from PQAnalysis.type_checking import runtime_type_checking
+
+from .exceptions import BoxReaderError
+
+
+
+class BoxReader(BaseReader):
+
+    """
+    A class for reading data-style box files.
+    """
+
+    logger = logging.getLogger(__package_name__).getChild(__qualname__)
+    logger = setup_logger(logger)
+
+    @runtime_type_checking
+    def read(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Reads a data-style box file.
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, np.ndarray]
+            The steps, box lengths and box angles from the box file.
+        """
+        steps = []
+        box_lengths = []
+        box_angles = []
+
+        with open(self.filename, "r", encoding="utf-8") as file:
+            for line_number, line in enumerate(file, start=1):
+                line = line.strip()
+
+                if line == "" or line.startswith("#"):
+                    continue
+
+                step, lengths, angles = self._parse_line(line, line_number)
+
+                steps.append(step)
+                box_lengths.append(lengths)
+                box_angles.append(angles)
+
+        return (
+            np.array(steps, dtype=int),
+            np.array(box_lengths, dtype=float),
+            np.array(box_angles, dtype=float),
+        )
+
+    @classmethod
+    def _parse_line(
+        cls,
+        line: str,
+        line_number: int,
+    ) -> tuple[int, list[float], list[float]]:
+        """
+        Parses a data-style box file line.
+        """
+        values = line.split()
+
+        if len(values) != 7:
+            cls.logger.error(
+                (
+                    f"Invalid number of columns in box file line {line_number}. "
+                    "Expected 7 columns."
+                ),
+                exception=BoxReaderError
+            )
+
+        try:
+            step = int(values[0])
+            box_lengths = [float(value) for value in values[1:4]]
+            box_angles = [float(value) for value in values[4:]]
+        except ValueError:
+            cls.logger.error(
+                (
+                    f"Invalid numeric value in box file line {line_number}: "
+                    f"{line}"
+                ),
+                exception=BoxReaderError
+            )
+
+        return step, box_lengths, box_angles
+
+
+@runtime_type_checking
+def read_box(filename: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Reads a data-style box file.
+
+    Parameters
+    ----------
+    filename : str
+        The box file to read.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        The steps, box lengths and box angles from the box file.
+    """
+    return BoxReader(filename).read()

--- a/PQAnalysis/io/exceptions.py
+++ b/PQAnalysis/io/exceptions.py
@@ -14,6 +14,14 @@ class BoxWriterError(PQException):
 
 
 
+class BoxReaderError(PQException):
+
+    """
+    Exception raised for errors related to the BoxReader class
+    """
+
+
+
 class MoldescriptorReaderError(PQException):
 
     """

--- a/tests/io/test_boxReader.py
+++ b/tests/io/test_boxReader.py
@@ -1,0 +1,80 @@
+import pytest
+import numpy as np
+
+from . import pytestmark
+
+from PQAnalysis.exceptions import PQFileNotFoundError
+from PQAnalysis.io import BoxReader, read_box
+from PQAnalysis.io.exceptions import BoxReaderError
+
+
+
+class TestBoxReader:
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test__init__(self):
+        with pytest.raises(PQFileNotFoundError) as exception:
+            BoxReader("tmp")
+        assert str(exception.value) == "File tmp not found."
+
+        with open("box.dat", "w", encoding="utf-8") as file:
+            print("1 1.0 2.0 3.0 90.0 90.0 90.0", file=file)
+
+        reader = BoxReader("box.dat")
+
+        assert reader.filename == "box.dat"
+        assert reader.multiple_files is False
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_read(self):
+        with open("box.dat", "w", encoding="utf-8") as file:
+            print("# step x y z alpha beta gamma", file=file)
+            print("1 1.1 1.2 1.3 90.0 91.0 92.0", file=file)
+            print("", file=file)
+            print("2 2.1 2.2 2.3 80.0 81.0 82.0", file=file)
+
+        steps, box_lengths, box_angles = BoxReader("box.dat").read()
+
+        assert np.array_equal(steps, np.array([1, 2]))
+        assert np.allclose(
+            box_lengths,
+            np.array([[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]])
+        )
+        assert np.allclose(
+            box_angles,
+            np.array([[90.0, 91.0, 92.0], [80.0, 81.0, 82.0]])
+        )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_read_box(self):
+        with open("box.dat", "w", encoding="utf-8") as file:
+            print("1 1.0 2.0 3.0 90.0 91.0 92.0", file=file)
+
+        steps, box_lengths, box_angles = read_box("box.dat")
+
+        assert np.array_equal(steps, np.array([1]))
+        assert np.allclose(box_lengths, np.array([[1.0, 2.0, 3.0]]))
+        assert np.allclose(box_angles, np.array([[90.0, 91.0, 92.0]]))
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_invalid_number_of_columns(self):
+        with open("box.dat", "w", encoding="utf-8") as file:
+            print("1 1.0 1.0", file=file)
+
+        with pytest.raises(BoxReaderError) as exception:
+            BoxReader("box.dat").read()
+        assert str(exception.value) == (
+            "Invalid number of columns in box file line 1. Expected 7 columns."
+        )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_invalid_numeric_value(self):
+        with open("box.dat", "w", encoding="utf-8") as file:
+            print("1 bad 1.0 1.0 90.0 90.0 90.0", file=file)
+
+        with pytest.raises(BoxReaderError) as exception:
+            BoxReader("box.dat").read()
+        assert str(exception.value) == (
+            "Invalid numeric value in box file line 1: "
+            "1 bad 1.0 1.0 90.0 90.0 90.0"
+        )


### PR DESCRIPTION
Summary:
- Add a reader for data-style box files.
- Expose a read_box API helper.
- Add coverage for valid and invalid box files.

Resolves #13.