### PR TITLE
feat: continue inputs with unnumbered starts

### DIFF
--- a/PQAnalysis/io/api.py
+++ b/PQAnalysis/io/api.py
@@ -45,11 +45,11 @@ def continue_input_file(
     Raises
     ------
     NotImplementedError
-        if the input format is not PQ
+        if the input format is not PQ or QMCFC
     """
     input_format = InputFileFormat(input_format)
 
-    if input_format != InputFileFormat.PQ:
+    if not InputFileFormat.is_qmcf_type(input_format):
         logger.error(
             (
             f"Format {input_format} not implemented "

--- a/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
+++ b/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
@@ -99,7 +99,14 @@ class PQInputFileReader(_OutputFileMixin):
             if the n parsed from the start file does not match the n parsed from the output files
         """
         self.input_file_n = _get_digit_string_from_filename(self.filename)
-        self.start_n = self._parse_start_n()
+        start_file_ns = self._parse_start_file_ns()
+        self.start_n = next(
+            (
+                start_n for start_n in start_file_ns.values()
+                if start_n is not None
+            ),
+            None
+        )
         self.actual_n = self._parse_actual_n()
 
         # check if n from input file name matches n from output files
@@ -110,7 +117,7 @@ class PQInputFileReader(_OutputFileMixin):
             )
 
         # check if n from start file matches n from output files
-        if int(self.start_n) != int(self.actual_n) - 1:
+        if self.start_n is not None and int(self.start_n) != int(self.actual_n) - 1:
             self.logger.error(
                 f"Old n ({self.start_n}) has to be one less than actual n ({self.actual_n}).",
                 exception=PQValueError
@@ -122,7 +129,11 @@ class PQInputFileReader(_OutputFileMixin):
 
         for _ in range(n):
             new_input_file_n = _increase_digit_string(old_input_file_n)
-            new_start_n = _increase_digit_string(old_start_n)
+            new_start_n = (
+                _increase_digit_string(old_start_n)
+                if old_start_n is not None
+                else old_actual_n
+            )
             new_actual_n = _increase_digit_string(old_actual_n)
 
             new_raw_input_file = self.raw_input_file
@@ -143,9 +154,12 @@ class PQInputFileReader(_OutputFileMixin):
             for key in self.start_file_keys:
                 if key in self.dictionary.keys():
 
-                    new_filename = self.dictionary[key][0].replace(
-                        self.start_n, new_start_n
-                    )
+                    if start_file_ns[key] is None:
+                        new_filename = self._continued_start_file(key, new_start_n)
+                    else:
+                        new_filename = self.dictionary[key][0].replace(
+                            start_file_ns[key], new_start_n
+                        )
 
                     new_raw_input_file = new_raw_input_file.replace(
                         self.dictionary[key][0], new_filename
@@ -163,6 +177,50 @@ class PQInputFileReader(_OutputFileMixin):
             old_input_file_n = new_input_file_n
             old_start_n = new_start_n
             old_actual_n = new_actual_n
+
+    def _parse_start_file_ns(self) -> dict[str, str | None]:
+        """
+        Parses the n from the start files.
+
+        If multiple start files define a number, the numbers are compared. If
+        they do not match, a PQValueError is raised. Start files without a
+        parseable number are allowed and are continued from restart output.
+
+        Returns
+        -------
+        dict[str, str | None]
+            n parsed from each start file as a digit string or None if the
+            filename has no parseable digit string
+
+        Raises
+        ------
+        PQValueError
+            if the n from multiple start files do not match
+        """
+        start_file_ns = {}
+
+        for key in self.start_file_keys:
+            if key in self.dictionary.keys():
+                start_file_ns[key] = _get_optional_digit_string_from_filename(
+                    self.dictionary[key][0] + "."
+                )
+
+        n = next(
+            (start_n for start_n in start_file_ns.values() if start_n is not None),
+            None
+        )
+
+        for key, start_n in start_file_ns.items():
+            if start_n is not None and start_n != n:
+                self.logger.error(
+                    (
+                        f"N from start_file ({n}) and "
+                        f"{key} ({start_n}) do not match."
+                    ),
+                    exception=PQValueError
+                )
+
+        return start_file_ns
 
     def _parse_start_n(self) -> str:
         """
@@ -196,6 +254,34 @@ class PQInputFileReader(_OutputFileMixin):
                 )
 
         return n
+
+    def _continued_start_file(self, key: str, n: str) -> str:
+        """
+        Gets the next start file name for an unnumbered start file.
+        """
+        restart_key = "restart_file"
+
+        if key == "rpmd_start_file":
+            restart_key = "rpmd_restart_file"
+
+        if restart_key not in self.dictionary.keys() and key == "start_file":
+            restart_key = "rpmd_restart_file"
+
+        if restart_key not in self.dictionary.keys():
+            if "file_prefix" not in self.dictionary.keys():
+                return self.dictionary[key][0]
+
+            file_prefix = self.dictionary["file_prefix"][0].replace(
+                self.actual_n,
+                n
+            )
+
+            if key == "rpmd_start_file":
+                return f"{file_prefix}.rpmd.rst"
+
+            return f"{file_prefix}.rst"
+
+        return self.dictionary[restart_key][0].replace(self.actual_n, n)
 
     def _parse_actual_n(self) -> str:
         """
@@ -317,7 +403,7 @@ def _get_digit_string_from_filename(filename: str) -> str:
         if filename does not contain a number to be parsed
     """
 
-    if (regex := re.search(r"\d+\.", filename)) is None:
+    if (digit_string := _get_optional_digit_string_from_filename(filename)) is None:
         PQInputFileReader.logger.error(
             (
                 f"Filename {filename} does not contain a number to be "
@@ -325,5 +411,16 @@ def _get_digit_string_from_filename(filename: str) -> str:
             ),
             exception=PQValueError
         )
+
+    return digit_string
+
+
+
+def _get_optional_digit_string_from_filename(filename: str) -> str | None:
+    """
+    Extracts a digit string from a filename if one can be parsed.
+    """
+    if (regex := re.search(r"\d+\.", filename)) is None:
+        return None
 
     return regex.group(0)[:-1]

--- a/tests/cli/test_continue_input.py
+++ b/tests/cli/test_continue_input.py
@@ -24,11 +24,22 @@ def test_continue_input(test_with_data_dir, capsys):
             '-n',
             '1',
             '--input-format',
-            'qmcfc']):
+            'PQAnalysis']):
             main()
     assert str(
         exception.value
-    ) == "Format InputFileFormat.QMCFC not implemented yet for continuing input file."
+    ) == "Format InputFileFormat.PQANALYSIS not implemented yet for continuing input file."
+
+    with patch('argparse._sys.argv',
+        ['continue_input.py',
+        'run-08.in',
+        '-n',
+        '1',
+        '--input-format',
+        'qmcfc']):
+        main()
+
+    assert filecmp("run-09.in", "run-09.in.ref")
 
     with patch('argparse._sys.argv',
         ['continue_input.py',

--- a/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
+++ b/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
@@ -232,3 +232,116 @@ class TestPQ_inputFileReader:
 
         assert filecmp("run-09.rpmd.in", "run-09.rpmd.in.ref")
         assert filecmp("run-10.rpmd.in", "run-10.rpmd.in.ref")
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_input_file_with_unnumbered_start_file(self):
+        with open("run-08.in", "w", encoding="utf-8") as file:
+            file.write(
+                "start_file = equilibration.rst;\n"
+                "output_file = md-08.out;\n"
+                "restart_file = md-08.rst;\n"
+                "traj_file = md-08.xyz;\n"
+            )
+
+        input_file_reader = InputFileReader("run-08.in")
+        input_file_reader.read()
+        input_file_reader.continue_input_file(2)
+
+        with open("run-09.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = md-08.rst;\n"
+                "output_file = md-09.out;\n"
+                "restart_file = md-09.rst;\n"
+                "traj_file = md-09.xyz;\n"
+            )
+
+        with open("run-10.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = md-09.rst;\n"
+                "output_file = md-10.out;\n"
+                "restart_file = md-10.rst;\n"
+                "traj_file = md-10.xyz;\n"
+            )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_parse_start_file_ns_rejects_mismatched_numbered_start_files(self):
+        with open("run-08.in", "w", encoding="utf-8") as file:
+            file.write(
+                "start_file = md-07.rst;\n"
+                "rpmd_start_file = md-08.rpmd.rst;\n"
+                "output_file = md-08.out;\n"
+            )
+
+        input_file_reader = InputFileReader("run-08.in")
+        input_file_reader.read()
+
+        with pytest.raises(PQValueError) as exception:
+            input_file_reader._parse_start_file_ns()
+
+        assert str(exception.value) == (
+            "N from start_file (07) and rpmd_start_file (08) do not match."
+        )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_input_file_keeps_unnumbered_start_without_fallback(self):
+        with open("run-08.in", "w", encoding="utf-8") as file:
+            file.write(
+                "start_file = equilibration.rst;\n"
+                "output_file = md-08.out;\n"
+            )
+
+        input_file_reader = InputFileReader("run-08.in")
+        input_file_reader.read()
+        input_file_reader.continue_input_file(1)
+
+        with open("run-09.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = equilibration.rst;\n"
+                "output_file = md-09.out;\n"
+            )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_input_file_uses_prefix_for_unnumbered_rpmd_start_file(self):
+        with open("run-08.in", "w", encoding="utf-8") as file:
+            file.write(
+                "start_file = md-07.rst;\n"
+                "rpmd_start_file = equilibration.rpmd.rst;\n"
+                "file_prefix = md-08;\n"
+                "output_file = md-08.out;\n"
+            )
+
+        input_file_reader = InputFileReader("run-08.in")
+        input_file_reader.read()
+        input_file_reader.continue_input_file(1)
+
+        with open("run-09.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = md-08.rst;\n"
+                "rpmd_start_file = md-08.rpmd.rst;\n"
+                "file_prefix = md-09;\n"
+                "output_file = md-09.out;\n"
+            )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_input_file_with_unnumbered_start_file_and_file_prefix(self):
+        with open("run-01.in", "w", encoding="utf-8") as file:
+            file.write(
+                "start_file = input.rst;\n"
+                "file_prefix = malondialdehyde-md-01;\n"
+            )
+
+        input_file_reader = InputFileReader("run-01.in")
+        input_file_reader.read()
+        input_file_reader.continue_input_file(2)
+
+        with open("run-02.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = malondialdehyde-md-01.rst;\n"
+                "file_prefix = malondialdehyde-md-02;\n"
+            )
+
+        with open("run-03.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "start_file = malondialdehyde-md-02.rst;\n"
+                "file_prefix = malondialdehyde-md-03;\n"
+            )


### PR DESCRIPTION
Summary:
- Allow continue_input to handle QMCFC input format.
- Continue unnumbered start files from restart outputs or file_prefix.
- Add coverage for PQ-style first-run inputs.

Resolves #90.