### PR TITLE
feat: read extended xyz trajectories

### DIFF
--- a/PQAnalysis/io/__init__.py
+++ b/PQAnalysis/io/__init__.py
@@ -23,6 +23,7 @@ from .traj_file.trajectory_writer import TrajectoryWriter
 from .traj_file.frame_reader import (
     BaseFrameReader,
     XYZFrameReader,
+    ExtXYZFrameReader,
     _FrameReader,
     get_frame_reader,
 )

--- a/PQAnalysis/io/traj_file/__init__.py
+++ b/PQAnalysis/io/traj_file/__init__.py
@@ -7,6 +7,7 @@ from .trajectory_writer import TrajectoryWriter
 from .frame_reader import (
     BaseFrameReader,
     XYZFrameReader,
+    ExtXYZFrameReader,
     _FrameReader,
     get_frame_reader,
 )

--- a/PQAnalysis/io/traj_file/frame_reader.py
+++ b/PQAnalysis/io/traj_file/frame_reader.py
@@ -3,6 +3,7 @@ A module containing classes for reading a frame from a string.
 """
 
 import logging
+import shlex
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -457,6 +458,367 @@ class _FrameReader(XYZFrameReader):
     """
 
 
+class ExtXYZFrameReader(BaseFrameReader):
+
+    """
+    A frame reader for extended xyz position frames.
+    """
+
+    logger = logging.getLogger(__package_name__).getChild(__qualname__)
+    logger = setup_logger(logger)
+
+    def read(
+        self,
+        frame_string: str,
+        topology: Topology | None = None,
+        traj_format: TrajectoryFormat | str = TrajectoryFormat.EXTXYZ
+    ) -> AtomicSystem:
+        """
+        Reads an extended xyz frame from a string.
+        """
+        traj_format = TrajectoryFormat(traj_format)
+        if traj_format is not TrajectoryFormat.EXTXYZ:
+            message = f'Invalid TrajectoryFormat given. {traj_format=}'
+            self.logger.error(message, exception=FrameReaderError)
+
+        self.topology = topology
+
+        lines = frame_string.split('\n')
+        n_atoms = self._read_atom_count(lines[0])
+        metadata = self._read_metadata(lines[1])
+        properties = self._read_properties(metadata)
+
+        values, atoms = self._read_property_values(lines, n_atoms, properties)
+        values, atoms = self._check_qmcfc_properties(values, atoms)
+
+        topology = self._get_topology(atoms, self.topology)
+
+        return AtomicSystem(
+            topology=topology,
+            pos=values["pos"],
+            vel=values.get("vel", None),
+            forces=values.get("forces", None),
+            charges=values.get("charges", None),
+            energy=self._read_float_metadata(metadata, "energy"),
+            virial=self._read_matrix_metadata(metadata, "virial"),
+            stress=self._read_matrix_metadata(metadata, "stress"),
+            cell=self._read_cell(metadata),
+        )
+
+    def _read_atom_count(  # pylint: disable=inconsistent-return-statements
+        self,
+        line: str
+    ) -> int:
+        """
+        Reads the number of atoms from the first line.
+        """
+        try:
+            return int(line.split()[0])
+        except (ValueError, IndexError):
+            self.logger.error(
+                'Invalid number of atoms in extended xyz frame.',
+                exception=FrameReaderError
+            )
+
+    def _read_metadata(self, line: str) -> dict[str, str]:
+        """
+        Parses extended xyz key-value metadata from the comment line.
+        """
+        metadata = {}
+        tokens = shlex.split(line)
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+            if i + 2 < len(tokens) and tokens[i + 1] == "=":
+                metadata[token.lower()] = tokens[i + 2]
+                i += 3
+            elif "=" in token and token != "=":
+                key, value = token.split("=", 1)
+                if value == "" and i + 1 < len(tokens):
+                    i += 1
+                    value = tokens[i]
+                metadata[key.lower()] = value
+                i += 1
+            else:
+                i += 1
+
+        return metadata
+
+    def _read_properties(
+        self,
+        metadata: dict[str, str],
+    ) -> dict[str, tuple[int, int]]:
+        """
+        Reads the extxyz Properties metadata.
+        """
+        if "properties" not in metadata:
+            self.logger.error(
+                "Extended xyz frame does not define Properties metadata.",
+                exception=FrameReaderError
+            )
+
+        property_values = metadata["properties"].split(":")
+        if len(property_values) % 3 != 0:
+            self._raise_invalid_properties()
+
+        properties = {}
+        column_index = 0
+        for i in range(0, len(property_values), 3):
+            name = property_values[i].lower()
+
+            try:
+                column_count = int(property_values[i + 2])
+            except ValueError:
+                self._raise_invalid_properties()
+
+            properties[name] = (column_index, column_count)
+            column_index += column_count
+
+        if "species" not in properties or "pos" not in properties:
+            self.logger.error(
+                "Extended xyz frame requires species and pos Properties.",
+                exception=FrameReaderError
+            )
+
+        if properties["species"][1] != 1 or properties["pos"][1] != 3:
+            self._raise_invalid_properties()
+
+        return properties
+
+    def _raise_invalid_properties(self) -> None:
+        """
+        Raises a consistent error for invalid Properties metadata.
+        """
+        self.logger.error(
+            "Invalid Properties metadata in extended xyz frame.",
+            exception=FrameReaderError
+        )
+
+    def _read_property_values(
+        self,
+        lines: list[str],
+        n_atoms: int,
+        properties: dict[str, tuple[int, int]],
+    ) -> tuple[dict[str, np.ndarray], list[str]]:
+        """
+        Reads atom and numeric property values from frame lines.
+        """
+        atoms = []
+        values = {
+            "pos": np.zeros((n_atoms, 3)),
+        }
+
+        optional_properties = {
+            "vel": ("vel", 3),
+            "velocity": ("vel", 3),
+            "forces": ("forces", 3),
+            "force": ("forces", 3),
+            "charge": ("charges", 1),
+            "charges": ("charges", 1),
+        }
+
+        for extxyz_name, (property_name, column_count) in optional_properties.items():
+            if extxyz_name in properties:
+                if properties[extxyz_name][1] != column_count:
+                    self._raise_invalid_properties()
+
+                values[property_name] = self._empty_property_array(
+                    n_atoms,
+                    column_count,
+                )
+
+        for i in range(n_atoms):
+            try:
+                line_values = lines[2 + i].split()
+            except IndexError:
+                self.logger.error(
+                    "Invalid atom line in extended xyz frame.",
+                    exception=FrameReaderError
+                )
+
+            if len(line_values) < self._properties_column_count(properties):
+                self.logger.error(
+                    "Invalid atom line in extended xyz frame.",
+                    exception=FrameReaderError
+                )
+
+            atoms.append(line_values[properties["species"][0]])
+            values["pos"][i] = self._read_numeric_property(
+                line_values,
+                properties["pos"],
+            )
+
+            for extxyz_name, (property_name, _) in optional_properties.items():
+                if extxyz_name in properties:
+                    values[property_name][i] = self._read_numeric_property(
+                        line_values,
+                        properties[extxyz_name],
+                    )
+
+        return values, atoms
+
+    def _check_qmcfc_properties(
+        self,
+        values: dict[str, np.ndarray],
+        atoms: list[str],
+    ) -> tuple[dict[str, np.ndarray], list[str]]:
+        """
+        Removes the QMCFC dummy atom and matching per-atom values.
+        """
+        if self.md_format != MDEngineFormat.QMCFC:
+            return values, atoms
+
+        if not atoms or atoms[0].upper() != "X":
+            self.logger.error(
+                (
+                    'The first atom in one of the frames is not X. '
+                    'Please use PQ (default) md engine instead'
+                ),
+                exception=FrameReaderError
+            )
+
+        return {key: value[1:] for key, value in values.items()}, atoms[1:]
+
+    def _properties_column_count(
+        self,
+        properties: dict[str, tuple[int, int]]
+    ) -> int:
+        """
+        Gets the total number of columns described by Properties metadata.
+        """
+        return max(
+            column_index + column_count
+            for column_index, column_count in properties.values()
+        )
+
+    def _empty_property_array(
+        self,
+        n_atoms: int,
+        column_count: int,
+    ) -> np.ndarray:
+        """
+        Creates an empty property array.
+        """
+        if column_count == 1:
+            return np.zeros(n_atoms)
+
+        return np.zeros((n_atoms, column_count))
+
+    def _read_numeric_property(
+        self,
+        line_values: list[str],
+        property_columns: tuple[int, int],
+    ) -> float | list[float]:
+        """
+        Reads a numeric property from atom line values.
+        """
+        column_index, column_count = property_columns
+        try:
+            values = [
+                float(value)
+                for value in line_values[column_index:column_index + column_count]
+            ]
+        except ValueError:
+            self.logger.error(
+                "Invalid numeric value in extended xyz frame.",
+                exception=FrameReaderError
+            )
+
+        if column_count == 1:
+            return values[0]
+
+        return values
+
+    def _read_cell(self, metadata: dict[str, str]) -> Cell:
+        """
+        Reads the cell from Lattice metadata.
+        """
+        if "lattice" not in metadata:
+            return Cell()
+
+        try:
+            lattice = np.array(
+                [float(value) for value in metadata["lattice"].split()]
+            ).reshape((3, 3))
+        except ValueError:
+            self.logger.error(
+                "Invalid Lattice metadata in extended xyz frame.",
+                exception=FrameReaderError
+            )
+
+        return self._cell_from_lattice(lattice)
+
+    def _cell_from_lattice(self, lattice: np.ndarray) -> Cell:
+        """
+        Builds a cell from the three extended xyz lattice vectors.
+        """
+        vector_a, vector_b, vector_c = lattice
+
+        a = np.linalg.norm(vector_a)
+        b = np.linalg.norm(vector_b)
+        c = np.linalg.norm(vector_c)
+
+        alpha = self._angle_between(vector_b, vector_c)
+        beta = self._angle_between(vector_a, vector_c)
+        gamma = self._angle_between(vector_a, vector_b)
+
+        return Cell(a, b, c, alpha, beta, gamma)
+
+    def _angle_between(self, vector_a: np.ndarray, vector_b: np.ndarray) -> float:
+        """
+        Calculates the angle between two vectors in degrees.
+        """
+        denominator = np.linalg.norm(vector_a) * np.linalg.norm(vector_b)
+        if denominator == 0.0:
+            self.logger.error(
+                "Invalid Lattice metadata in extended xyz frame.",
+                exception=FrameReaderError
+            )
+
+        cosine = np.dot(vector_a, vector_b) / denominator
+        return np.rad2deg(np.arccos(np.clip(cosine, -1.0, 1.0)))
+
+    def _read_float_metadata(  # pylint: disable=inconsistent-return-statements
+        self,
+        metadata: dict[str, str],
+        key: str,
+    ) -> float | None:
+        """
+        Reads a float metadata value if present.
+        """
+        if key not in metadata:
+            return None
+
+        try:
+            return float(metadata[key])
+        except ValueError:
+            self.logger.error(
+                f"Invalid {key} metadata in extended xyz frame.",
+                exception=FrameReaderError
+            )
+
+    def _read_matrix_metadata(  # pylint: disable=inconsistent-return-statements
+        self,
+        metadata: dict[str, str],
+        key: str,
+    ) -> np.ndarray | None:
+        """
+        Reads a 3x3 matrix metadata value if present.
+        """
+        if key not in metadata:
+            return None
+
+        try:
+            return np.array(
+                [float(value) for value in metadata[key].split()]
+            ).reshape((3, 3))
+        except ValueError:
+            self.logger.error(
+                f"Invalid {key} metadata in extended xyz frame.",
+                exception=FrameReaderError
+            )
+
+
 XYZ_FRAME_READER_TRAJ_FORMATS = (
     TrajectoryFormat.XYZ,
     TrajectoryFormat.VEL,
@@ -476,6 +838,9 @@ def get_frame_reader(
     traj_format = TrajectoryFormat(traj_format)
     if traj_format in XYZ_FRAME_READER_TRAJ_FORMATS:
         return XYZFrameReader(md_format=md_format)
+
+    if traj_format == TrajectoryFormat.EXTXYZ:
+        return ExtXYZFrameReader(md_format=md_format)
 
     # This should never happen - only for safety
     message = f'Invalid TrajectoryFormat given. {traj_format=}'

--- a/PQAnalysis/io/traj_file/trajectory_reader.py
+++ b/PQAnalysis/io/traj_file/trajectory_reader.py
@@ -78,6 +78,8 @@ class TrajectoryReader(BaseReader):
         self.frame_reader = get_frame_reader(
             self.traj_format, md_format=self.md_format
         )
+        if self.traj_format == TrajectoryFormat.EXTXYZ and topology is None:
+            self.constant_topology = False
 
         # The length of the trajectory
         self.length_of_traj = 0
@@ -478,6 +480,12 @@ class TrajectoryReader(BaseReader):
         for filename in self.filenames:
             n_frames = 0
 
+            if self.traj_format == TrajectoryFormat.EXTXYZ:
+                n_frames_list.append(
+                    self._calculate_number_of_extxyz_frames(filename)
+                )
+                continue
+
             with open(filename, "r", encoding="utf-8") as f:
 
                 lines = f.readlines()
@@ -511,6 +519,56 @@ class TrajectoryReader(BaseReader):
             n_frames_list.append(n_frames)
 
         return n_frames_list
+
+    def _calculate_number_of_extxyz_frames(self, filename: str) -> int:
+        """
+        Calculates the number of frames in an extended xyz trajectory file.
+        """
+        n_frames = 0
+
+        with open(filename, "r", encoding="utf-8") as f:
+            while True:
+                atom_count_line = f.readline()
+                if atom_count_line == "":
+                    break
+
+                if atom_count_line.strip() == "":
+                    continue
+
+                n_atoms = 0
+                try:
+                    n_atoms = int(atom_count_line.split()[0])
+                except (ValueError, IndexError):
+                    self.logger.error(
+                        (
+                            "Invalid number of atoms in the first line "
+                            f"of file {filename}."
+                        ),
+                        exception=TrajectoryReaderError,
+                    )
+
+                if f.readline() == "":
+                    self.logger.error(
+                        (
+                            "The number of lines in the file is not divisible "
+                            f"by the number of atoms {n_atoms} in one frame."
+                        ),
+                        exception=TrajectoryReaderError,
+                    )
+
+                for _ in range(n_atoms):
+                    if f.readline() == "":
+                        self.logger.error(
+                            (
+                                "The number of lines in the file is not divisible "
+                                f"by the number of atoms {n_atoms} in one frame."
+                            ),
+                            exception=TrajectoryReaderError,
+                        )
+
+                n_frames += 1
+
+        return n_frames
 
     @property
     def cells(self) -> list[Cell]:

--- a/PQAnalysis/traj/formats.py
+++ b/PQAnalysis/traj/formats.py
@@ -38,6 +38,9 @@ class TrajectoryFormat(BaseEnumFormat):
     #: The charge trajectory format.
     CHARGE = "CHARGE"
 
+    #: The extended xyz trajectory format.
+    EXTXYZ = "EXTXYZ"
+
     @classmethod
     def _missing_(cls, values: Any) -> Any:  # pylint: disable=arguments-differ
         """
@@ -90,7 +93,16 @@ class TrajectoryFormat(BaseEnumFormat):
         TrajectoryFormat
             The inferred trajectory format.
         """
+        if (
+            file_path.endswith(".extxyz") or
+            file_path.endswith(".extended.xyz")
+        ):
+            return cls.EXTXYZ
+
         if file_path.endswith(".xyz"):
+            if cls._is_extxyz_file(file_path):
+                return cls.EXTXYZ
+
             return cls.XYZ
 
         if (file_path.endswith(".vel") or file_path.endswith(".velocs")):
@@ -110,6 +122,20 @@ class TrajectoryFormat(BaseEnumFormat):
             ),
             exception=TrajectoryFormatError
         )
+
+    @staticmethod
+    def _is_extxyz_file(file_path: str) -> bool:
+        """
+        Check whether an xyz file uses the extended xyz comment line.
+        """
+        try:
+            with open(file_path, "r", encoding="utf-8") as file:
+                file.readline()
+                comment_line = file.readline().lower()
+        except OSError:
+            return False
+
+        return "properties" in comment_line
 
     def lower(self) -> str:
         """

--- a/tests/io/test_frameReader.py
+++ b/tests/io/test_frameReader.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from PQAnalysis.core import Cell, Atom
-from PQAnalysis.io import _FrameReader
+from PQAnalysis.io import ExtXYZFrameReader, _FrameReader
 from PQAnalysis.io.traj_file import _process_lines_py
 import PQAnalysis.io.traj_file.frame_reader as frame_reader
 from PQAnalysis.io.traj_file.exceptions import FrameReaderError
@@ -41,6 +41,13 @@ def test_get_frame_reader(traj_format):
     reader = frame_reader.get_frame_reader(traj_format)
 
     assert isinstance(reader, frame_reader.XYZFrameReader)
+
+
+def test_get_frame_reader_extxyz():
+    reader = frame_reader.get_frame_reader(TrajectoryFormat.EXTXYZ)
+
+    assert isinstance(reader, frame_reader.ExtXYZFrameReader)
+    assert isinstance(reader, ExtXYZFrameReader)
 
 
 def test_frame_reader_uses_python_fallback(monkeypatch):
@@ -163,6 +170,236 @@ def test_xyz_frame_reader_defensive_invalid_format_branch(monkeypatch):
         reader.read("", traj_format="unknown")
 
     assert str(exception.value) == "Invalid TrajectoryFormat given. traj_format='unknown'"
+
+
+def test_extxyz_frame_reader_reads_properties_and_metadata():
+    reader = frame_reader.ExtXYZFrameReader()
+    frame_string = (
+        '2\n'
+        'Lattice="10 0 0 0 20 0 0 0 30" '
+        'Properties=species:S:1:pos:R:3:forces:R:3:charge:R:1 '
+        'energy=-1.5 virial="1 0 0 0 2 0 0 0 3" '
+        'stress="4 0 0 0 5 0 0 0 6"\n'
+        'H 0 1 2 0.1 0.2 0.3 -0.1\n'
+        'O 3 4 5 0.4 0.5 0.6 -0.2'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert frame.n_atoms == 2
+    assert frame.atoms == [Atom("h"), Atom("o")]
+    assert np.allclose(frame.pos, [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+    assert np.allclose(frame.forces, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    assert np.allclose(frame.charges, [-0.1, -0.2])
+    assert frame.energy == -1.5
+    assert np.allclose(frame.virial, np.diag([1.0, 2.0, 3.0]))
+    assert np.allclose(frame.stress, np.diag([4.0, 5.0, 6.0]))
+    assert frame.cell == Cell(10.0, 20.0, 30.0)
+
+
+def test_extxyz_frame_reader_reads_nep_writer_style_header():
+    reader = frame_reader.ExtXYZFrameReader()
+    frame_string = (
+        '1\n'
+        'energy=-2.0 config_type=nep2xyz '
+        'lattice="2 0 0 0 3 0 0 0 4 " '
+        'properties=species:S:1:pos:R:3:forces:R:3\n'
+        'C 0.0 0.5 1.0 1.0 2.0 3.0'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert frame.atoms == [Atom("c")]
+    assert np.allclose(frame.pos, [[0.0, 0.5, 1.0]])
+    assert np.allclose(frame.forces, [[1.0, 2.0, 3.0]])
+    assert frame.energy == -2.0
+    assert frame.cell == Cell(2.0, 3.0, 4.0)
+
+
+def test_extxyz_frame_reader_reads_spaced_metadata_assignment():
+    reader = frame_reader.ExtXYZFrameReader()
+    frame_string = (
+        '1\n'
+        'Lattice = "4 0 0 0 5 0 0 0 6" '
+        'Properties=species:S:1:pos:R:3:force:R:3 Energy= -1.0\n'
+        'H 0.0 0.5 1.0 1.0 2.0 3.0'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert frame.atoms == [Atom("h")]
+    assert np.allclose(frame.pos, [[0.0, 0.5, 1.0]])
+    assert np.allclose(frame.forces, [[1.0, 2.0, 3.0]])
+    assert frame.energy == -1.0
+    assert frame.cell == Cell(4.0, 5.0, 6.0)
+
+
+def test_extxyz_frame_reader_reads_noncanonical_lattice_vectors():
+    reader = frame_reader.ExtXYZFrameReader()
+    lattice = np.array(
+        [
+            [0.0, 0.0, 5.785795211791992],
+            [5.928857803344727, 0.0, 0.0],
+            [-2.9644289016723633, 8.167890548706055, -2.892897605895996],
+        ]
+    )
+    frame_string = (
+        '1\n'
+        'Lattice="0.0 0.0 5.785795211791992 '
+        '5.928857803344727 0.0 0.0 '
+        '-2.9644289016723633 8.167890548706055 -2.892897605895996" '
+        'Properties=species:S:1:pos:R:3\n'
+        'H 0.0 0.0 0.0'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert np.isclose(frame.cell.volume, abs(np.linalg.det(lattice)))
+
+
+def test_extxyz_frame_reader_rejects_degenerate_lattice_vectors():
+    reader = frame_reader.ExtXYZFrameReader()
+    frame_string = (
+        '1\n'
+        'Lattice="0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0" '
+        'Properties=species:S:1:pos:R:3\n'
+        'H 0.0 0.0 0.0'
+    )
+
+    with pytest.raises(FrameReaderError) as exception:
+        reader.read(frame_string)
+
+    assert str(exception.value) == "Invalid Lattice metadata in extended xyz frame."
+
+
+def test_extxyz_frame_reader_preserves_qmcfc_handling():
+    reader = frame_reader.ExtXYZFrameReader(md_format="qmcfc")
+    frame_string = (
+        '2\n'
+        'Properties=species:S:1:pos:R:3:forces:R:3:charge:R:1\n'
+        'X 0 0 0 0 0 0 0.0\n'
+        'H 1 2 3 0.1 0.2 0.3 -0.1'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert frame.n_atoms == 1
+    assert frame.atoms == [Atom("h")]
+    assert np.allclose(frame.pos, [[1.0, 2.0, 3.0]])
+    assert np.allclose(frame.forces, [[0.1, 0.2, 0.3]])
+    assert np.allclose(frame.charges, [-0.1])
+
+
+def test_extxyz_frame_reader_rejects_invalid_format():
+    reader = frame_reader.ExtXYZFrameReader()
+
+    with pytest.raises(FrameReaderError) as exception:
+        reader.read("", traj_format=TrajectoryFormat.XYZ)
+
+    assert str(exception.value) == (
+        "Invalid TrajectoryFormat given. "
+        "traj_format=<TrajectoryFormat.XYZ: 'XYZ'>"
+    )
+
+
+@pytest.mark.parametrize(
+    ("frame_string", "expected", "md_format"),
+    [
+        (
+            "not-an-int\nProperties=species:S:1:pos:R:3\nH 0.0 0.0 0.0",
+            "Invalid number of atoms in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\ncomment\nH 0.0 0.0 0.0",
+            "Extended xyz frame does not define Properties metadata.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R\nH 0.0 0.0 0.0",
+            "Invalid Properties metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:three\nH 0.0 0.0 0.0",
+            "Invalid Properties metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=pos:R:3\n0.0 0.0 0.0",
+            "Extended xyz frame requires species and pos Properties.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:2\nH 0.0 0.0",
+            "Invalid Properties metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            (
+                "1\nProperties=species:S:1:pos:R:3:forces:R:2\n"
+                "H 0.0 0.0 0.0 1.0 2.0"
+            ),
+            "Invalid Properties metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:3",
+            "Invalid atom line in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:3\nH 0.0 0.0",
+            "Invalid atom line in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:3\nH 0.0 0.0 0.0",
+            (
+                "The first atom in one of the frames is not X. "
+                "Please use PQ (default) md engine instead"
+            ),
+            "qmcfc",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:3\nH 0.0 nope 0.0",
+            "Invalid numeric value in extended xyz frame.",
+            "pq",
+        ),
+        (
+            (
+                '1\nLattice="1 2" Properties=species:S:1:pos:R:3\n'
+                "H 0.0 0.0 0.0"
+            ),
+            "Invalid Lattice metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            "1\nProperties=species:S:1:pos:R:3 energy=nope\nH 0.0 0.0 0.0",
+            "Invalid energy metadata in extended xyz frame.",
+            "pq",
+        ),
+        (
+            (
+                '1\nProperties=species:S:1:pos:R:3 virial="1 2"\n'
+                "H 0.0 0.0 0.0"
+            ),
+            "Invalid virial metadata in extended xyz frame.",
+            "pq",
+        ),
+    ],
+)
+def test_extxyz_frame_reader_rejects_invalid_frames(
+    frame_string,
+    expected,
+    md_format,
+):
+    reader = frame_reader.ExtXYZFrameReader(md_format=md_format)
+
+    with pytest.raises(FrameReaderError) as exception:
+        reader.read(frame_string)
+
+    assert str(exception.value) == expected
 
 
 class TestFrameReader:

--- a/tests/io/test_trajectoryReader.py
+++ b/tests/io/test_trajectoryReader.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from PQAnalysis.traj import MDEngineFormat, Trajectory
+from PQAnalysis.traj import MDEngineFormat, Trajectory, TrajectoryFormat
 from PQAnalysis.io import TrajectoryReader
 import PQAnalysis.io.traj_file.frame_reader as frame_reader
 from PQAnalysis.io.traj_file.exceptions import FrameReaderError, TrajectoryReaderError
@@ -29,6 +29,154 @@ def test_calculate_number_of_frames():
     file.close()
 
     assert calculate_frames_of_trajectory_file("tmp.xyz") == 2
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_read_extxyz_trajectory_with_auto_format():
+    file = open("tmp.xyz", "w")
+    print("2", file=file)
+    print(
+        'Lattice="1 0 0 0 2 0 0 0 3" '
+        'Properties=species:S:1:pos:R:3:forces:R:3',
+        file=file,
+    )
+    print("H 0.0 0.0 0.0 0.1 0.2 0.3", file=file)
+    print("O 0.0 1.0 0.0 0.4 0.5 0.6", file=file)
+    print("2", file=file)
+    print(
+        'lattice="1 0 0 0 2 0 0 0 3" '
+        'properties=species:S:1:pos:R:3:charge:R:1',
+        file=file,
+    )
+    print("H 1.0 0.0 0.0 -0.1", file=file)
+    print("O 0.0 1.0 1.0 -0.2", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.xyz")
+    traj = reader.read()
+
+    assert reader.traj_format is TrajectoryFormat.EXTXYZ
+    assert isinstance(reader.frame_reader, frame_reader.ExtXYZFrameReader)
+    assert calculate_frames_of_trajectory_file("tmp.xyz") == 2
+    assert len(traj) == 2
+    assert traj[0].atoms == [Atom("h"), Atom("o")]
+    assert np.allclose(traj[0].pos, [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    assert np.allclose(traj[0].forces, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    assert traj[0].cell == Cell(1.0, 2.0, 3.0)
+    assert np.allclose(traj[1].pos, [[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+    assert np.allclose(traj[1].charges, [-0.1, -0.2])
+    assert traj[1].cell == Cell(1.0, 2.0, 3.0)
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_read_variable_size_extxyz_trajectory_with_auto_format():
+    file = open("tmp.extended.xyz", "w")
+    print("2", file=file)
+    print("Properties=species:S:1:pos:R:3", file=file)
+    print("H 0.0 0.0 0.0", file=file)
+    print("O 0.0 1.0 0.0", file=file)
+    print("1", file=file)
+    print("Properties=species:S:1:pos:R:3", file=file)
+    print("C 1.0 0.0 0.0", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.extended.xyz")
+    traj = reader.read()
+
+    assert reader.traj_format is TrajectoryFormat.EXTXYZ
+    assert reader.constant_topology is False
+    assert calculate_frames_of_trajectory_file("tmp.extended.xyz") == 2
+    assert len(traj) == 2
+    assert traj.frames[0].atoms == [Atom("h"), Atom("o")]
+    assert traj.frames[1].atoms == [Atom("c")]
+    assert np.allclose(traj.frames[1].pos, [[1.0, 0.0, 0.0]])
+
+
+def test_missing_xyz_file_infers_plain_xyz_for_format_only():
+    assert (
+        TrajectoryFormat.infer_format_from_extension("missing.xyz")
+        is TrajectoryFormat.XYZ
+    )
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_calculate_number_of_extxyz_frames_rejects_invalid_atom_count(caplog):
+    file = open("tmp.extxyz", "w")
+    print("not-an-int", file=file)
+    print("Properties=species:S:1:pos:R:3", file=file)
+    print("H 0.0 0.0 0.0", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.extxyz")
+
+    assert_logging_with_exception(
+        caplog,
+        TrajectoryReader.__qualname__,
+        exception=TrajectoryReaderError,
+        logging_level="ERROR",
+        message_to_test=(
+            "Invalid number of atoms in the first line of file tmp.extxyz."
+        ),
+        function=reader.calculate_number_of_frames_per_file,
+    )
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_calculate_number_of_extxyz_frames_skips_blank_lines():
+    file = open("tmp.extxyz", "w")
+    print("", file=file)
+    print("1", file=file)
+    print("Properties=species:S:1:pos:R:3", file=file)
+    print("H 0.0 0.0 0.0", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.extxyz")
+
+    assert reader.calculate_number_of_frames_per_file() == [1]
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_calculate_number_of_extxyz_frames_rejects_missing_comment(caplog):
+    file = open("tmp.extxyz", "w")
+    print("2", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.extxyz")
+
+    assert_logging_with_exception(
+        caplog,
+        TrajectoryReader.__qualname__,
+        exception=TrajectoryReaderError,
+        logging_level="ERROR",
+        message_to_test=(
+            "The number of lines in the file is not divisible "
+            "by the number of atoms 2 in one frame."
+        ),
+        function=reader.calculate_number_of_frames_per_file,
+    )
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_calculate_number_of_extxyz_frames_rejects_truncated_frame(caplog):
+    file = open("tmp.extxyz", "w")
+    print("2", file=file)
+    print("Properties=species:S:1:pos:R:3", file=file)
+    print("H 0.0 0.0 0.0", file=file)
+    file.close()
+
+    reader = TrajectoryReader("tmp.extxyz")
+
+    assert_logging_with_exception(
+        caplog,
+        TrajectoryReader.__qualname__,
+        exception=TrajectoryReaderError,
+        logging_level="ERROR",
+        message_to_test=(
+            "The number of lines in the file is not divisible "
+            "by the number of atoms 2 in one frame."
+        ),
+        function=reader.calculate_number_of_frames_per_file,
+    )
 
 
 


### PR DESCRIPTION
Summary:
- Add ExtXYZ format inference and frame-reader support.
- Parse Properties, Lattice, forces, charges, energy, virial, and stress metadata.
- Add frame and trajectory coverage.

Resolves #64.