### PR TITLE
feat: convert pq trajectories to extxyz

### DIFF
--- a/PQAnalysis/cli/main.py
+++ b/PQAnalysis/cli/main.py
@@ -5,6 +5,7 @@ A command line interface for the PQAnalysis package.
 from PQAnalysis.config import code_base_url
 
 from .xyz2gen import XYZ2GENCLI
+from .traj2extxyz import Traj2ExtXYZCLI
 from .traj2qmcfc import Traj2QMCFCCLI
 from .traj2box import Traj2BoxCLI
 from .rst2xyz import Rst2XYZCLI
@@ -46,6 +47,7 @@ def main():
         Rst2XYZCLI.program_name(): Rst2XYZCLI,
         XYZ2RstCLI.program_name(): XYZ2RstCLI,
         Traj2BoxCLI.program_name(): Traj2BoxCLI,
+        Traj2ExtXYZCLI.program_name(): Traj2ExtXYZCLI,
         Traj2QMCFCCLI.program_name(): Traj2QMCFCCLI,
         XYZ2GENCLI.program_name(): XYZ2GENCLI,
     }

--- a/PQAnalysis/cli/traj2extxyz.py
+++ b/PQAnalysis/cli/traj2extxyz.py
@@ -1,0 +1,99 @@
+"""
+.. _cli.traj2extxyz:
+
+Command Line Tool for Converting PQ Trajectory Files to Extended XYZ
+--------------------------------------------------------------------
+
+"""
+
+from PQAnalysis.config import code_base_url
+from PQAnalysis.io import traj2extxyz
+from ._argument_parser import _ArgumentParser
+from ._cli_base import CLIBase
+
+__outputdoc__ = """
+Converts PQ xyz trajectory files to extended xyz format.
+"""
+
+__epilog__ = "\n"
+__epilog__ += "For more information on required and optional input file keys please visit "
+__epilog__ += f"{code_base_url}PQAnalysis.cli.traj2extxyz.html."
+__epilog__ += "\n"
+__epilog__ += "\n"
+
+__doc__ += __outputdoc__
+
+
+
+class Traj2ExtXYZCLI(CLIBase):
+
+    """
+    Command Line Tool for Converting PQ Trajectory Files to Extended XYZ
+    """
+
+    @classmethod
+    def program_name(cls) -> str:
+        """
+        Returns the name of the program.
+
+        Returns
+        -------
+        str
+            The name of the program.
+        """
+        return 'traj2extxyz'
+
+    @classmethod
+    def add_arguments(cls, parser: _ArgumentParser) -> None:
+        """
+        Adds the arguments to the parser.
+
+        Parameters
+        ----------
+        parser : _ArgumentParser
+            The parser to which the arguments should be added.
+        """
+        parser.parse_output_file()
+
+        parser.add_argument(
+            'trajectory_file',
+            type=str,
+            nargs='+',
+            help='The trajectory file(s) to be converted.'
+        )
+
+        parser.parse_engine()
+        parser.parse_mode()
+
+    @classmethod
+    def run(cls, args) -> None:
+        """
+        Runs the command line tool.
+
+        Parameters
+        ----------
+        args : _Namespace
+            The arguments from the command line.
+        """
+        traj2extxyz(
+            args.trajectory_file,
+            args.output,
+            args.mode,
+            args.engine,
+        )
+
+
+
+def main():
+    """
+    Main function of the traj2extxyz command line tool, which is basically just
+    a wrapper for the traj2extxyz function. For more information on the
+    traj2extxyz function please visit :py:func:`PQAnalysis.io.api.traj2extxyz`.
+    """
+    parser = _ArgumentParser(description=__outputdoc__, epilog=__epilog__)
+
+    Traj2ExtXYZCLI.add_arguments(parser)
+
+    args = parser.parse_args()
+
+    Traj2ExtXYZCLI.run(args)

--- a/PQAnalysis/io/__init__.py
+++ b/PQAnalysis/io/__init__.py
@@ -56,5 +56,12 @@ from .input_file_reader import InputFileFormat
 
 from .api import continue_input_file
 from .conversion_api import (
-    gen2xyz, xyz2gen, rst2xyz, xyz2rst, traj2box, traj2qmcfc)
+    gen2xyz,
+    xyz2gen,
+    rst2xyz,
+    xyz2rst,
+    traj2box,
+    traj2qmcfc,
+    traj2extxyz,
+)
 from .write_api import write, write_box

--- a/PQAnalysis/io/conversion_api.py
+++ b/PQAnalysis/io/conversion_api.py
@@ -302,3 +302,42 @@ def traj2qmcfc(
         trajectory = reader.read()
 
         writer.write(trajectory)
+
+
+@runtime_type_checking
+def traj2extxyz(
+    trajectory_files: List[str],
+    output: str | None = None,
+    mode: FileWritingMode | str = "w",
+    md_format: MDEngineFormat | str = MDEngineFormat.PQ,
+) -> None:
+    """
+    Converts one or more PQ xyz trajectory files to extended xyz format and
+    prints it to stdout or writes it to a file.
+
+    Parameters
+    ----------
+    trajectory_files : list of str
+        The trajectory file(s) to be converted.
+    output : str, optional
+        The output file. If not specified, the output is printed to stdout.
+    mode : FileWritingMode | str, optional
+        The writing mode, by default "w". The following modes are available:
+        - "w": write
+        - "a": append
+        - "o": overwrite
+    md_format : MDEngineFormat | str, optional
+        The format of the input trajectory. The default is MDEngineFormat.PQ.
+    """
+
+    writer = TrajectoryWriter(filename=output, mode=mode)
+
+    for filename in trajectory_files:
+        reader = TrajectoryReader(
+            filename,
+            md_format=md_format,
+            traj_format="xyz",
+        )
+        trajectory = reader.read()
+
+        writer.write(trajectory, traj_type="extxyz")

--- a/PQAnalysis/io/traj_file/trajectory_writer.py
+++ b/PQAnalysis/io/traj_file/trajectory_writer.py
@@ -70,6 +70,8 @@ class TrajectoryWriter(BaseWriter):
 
         if self.type == TrajectoryFormat.XYZ:
             self._write_positions(trajectory)
+        elif self.type == TrajectoryFormat.EXTXYZ:
+            self._write_extxyz(trajectory)
         elif self.type == TrajectoryFormat.VEL:
             self._write_velocities(trajectory)
         elif self.type == TrajectoryFormat.FORCE:
@@ -91,6 +93,23 @@ class TrajectoryWriter(BaseWriter):
             self._write_header(frame.n_atoms, frame.cell)
             self._write_comment(frame)
             self._write_xyz(frame.pos, frame.atoms)
+
+        self.close()
+
+    def _write_extxyz(self, trajectory: Trajectory) -> None:
+        """
+        Writes the trajectory in extended xyz format.
+
+        Parameters
+        ----------
+        trajectory : Trajectory
+            The trajectory to write.
+        """
+        self.open()
+        for frame in trajectory:
+            print(frame.n_atoms, file=self.file)
+            self._write_extxyz_metadata(frame)
+            self._write_extxyz_values(frame)
 
         self.close()
 
@@ -228,7 +247,101 @@ class TrajectoryWriter(BaseWriter):
                     f"{xyz[i][1]:16.10f} {xyz[i][2]:16.10f}"
                     ),
                     file=self.file
+            )
+
+    def _write_extxyz_metadata(self, frame: AtomicSystem) -> None:
+        """
+        Writes the extended xyz metadata line of the frame.
+
+        Parameters
+        ----------
+        frame : AtomicSystem
+            The frame to write the metadata line of.
+        """
+        metadata = []
+        if frame.cell != Cell():
+            metadata.append(
+                f'Lattice="{self._format_extxyz_values(frame.cell.box_matrix.T)}"'
+            )
+
+        metadata.append(
+            f'Properties="{self._extxyz_properties(frame)}"'
+        )
+
+        if frame.has_energy:
+            metadata.append(f"energy={self._format_extxyz_value(frame.energy)}")
+
+        if frame.has_virial:
+            metadata.append(
+                f'virial="{self._format_extxyz_values(frame.virial)}"'
+            )
+
+        if frame.has_stress:
+            metadata.append(
+                f'stress="{self._format_extxyz_values(frame.stress)}"'
+            )
+
+        print(" ".join(metadata), file=self.file)
+
+    def _extxyz_properties(self, frame: AtomicSystem) -> str:
+        """
+        Returns the extended xyz Properties metadata value for a frame.
+        """
+        properties = ["species:S:1", "pos:R:3"]
+
+        if frame.has_vel:
+            properties.append("vel:R:3")
+
+        if frame.has_forces:
+            properties.append("forces:R:3")
+
+        if frame.has_charges:
+            properties.append("charge:R:1")
+
+        return ":".join(properties)
+
+    def _write_extxyz_values(self, frame: AtomicSystem) -> None:
+        """
+        Writes the atom value lines of an extended xyz frame.
+
+        Parameters
+        ----------
+        frame : AtomicSystem
+            The frame to write.
+        """
+        for i, atom in enumerate(frame.atoms):
+            values = [atom.name]
+            values.extend(self._format_extxyz_value(value) for value in frame.pos[i])
+
+            if frame.has_vel:
+                values.extend(
+                    self._format_extxyz_value(value) for value in frame.vel[i]
                 )
+
+            if frame.has_forces:
+                values.extend(
+                    self._format_extxyz_value(value) for value in frame.forces[i]
+                )
+
+            if frame.has_charges:
+                values.append(self._format_extxyz_value(frame.charges[i]))
+
+            print(" ".join(values), file=self.file)
+
+    def _format_extxyz_values(self, values: Np2DNumberArray) -> str:
+        """
+        Formats a numeric array as a flat extended xyz metadata value.
+        """
+        return " ".join(
+            self._format_extxyz_value(value)
+            for value in values.flatten()
+        )
+
+    def _format_extxyz_value(self, value) -> str:
+        """
+        Formats one extended xyz numeric value.
+        """
+        return f"{float(value):.10f}"
 
     def _write_scalar(
         self,

--- a/docs/source/userGuide/userGuide.rst
+++ b/docs/source/userGuide/userGuide.rst
@@ -58,5 +58,6 @@ Pure command line tools
 
 - :ref:`continue_input<cli.continue_input>`
 - :ref:`rst2xyz<cli.rst2xyz>`
+- :ref:`traj2extxyz<cli.traj2extxyz>`
 - :ref:`traj2qmcfc<cli.traj2qmcfc>`
 - :ref:`traj2box<cli.traj2box>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ PQAnalysis = ["grammar/*.lark", "io/traj_file/*.pyx"]
 [project.scripts]
 pqanalysis = "PQAnalysis.cli.main:main"
 traj2box = "PQAnalysis.cli.traj2box:main"
+traj2extxyz = "PQAnalysis.cli.traj2extxyz:main"
 traj2qmcfc = "PQAnalysis.cli.traj2qmcfc:main"
 rst2xyz = "PQAnalysis.cli.rst2xyz:main"
 xyz2rst = "PQAnalysis.cli.xyz2rst:main"

--- a/tests/cli/test_traj2extxyz.py
+++ b/tests/cli/test_traj2extxyz.py
@@ -1,0 +1,103 @@
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from PQAnalysis.cli.traj2extxyz import Traj2ExtXYZCLI, main, traj2extxyz
+from PQAnalysis.cli.main import main as pqanalysis_main
+from PQAnalysis.core import Atom, Cell
+from PQAnalysis.io import read_trajectory
+from PQAnalysis.traj import TrajectoryFormat
+
+from . import ArgparseNamespace
+
+
+
+def _write_pq_xyz(filename: str) -> None:
+    with open(filename, "w", encoding="utf-8") as file:
+        print("2 10.0 11.0 12.0 90.0 90.0 90.0", file=file)
+        print("", file=file)
+        print("H 0.0 0.0 0.0", file=file)
+        print("O 0.0 0.0 1.0", file=file)
+
+
+def _assert_extxyz_output(filename: str) -> None:
+    from ase.io import read as ase_read
+
+    with open(filename, "r", encoding="utf-8") as file:
+        lines = file.read().splitlines()
+
+    assert lines[0] == "2"
+    assert "Lattice=" in lines[1]
+    assert 'Properties="species:S:1:pos:R:3"' in lines[1]
+
+    trajectory = read_trajectory(filename, traj_format=TrajectoryFormat.EXTXYZ)
+    frame = trajectory[0]
+
+    assert frame.atoms == [Atom("h"), Atom("o")]
+    assert np.allclose(frame.pos, [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    assert frame.cell == Cell(10.0, 11.0, 12.0)
+
+    ase_frame = ase_read(filename, index=0)
+    assert ase_frame.get_chemical_symbols() == ["H", "O"]
+    assert np.allclose(ase_frame.cell.lengths(), [10.0, 11.0, 12.0])
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_traj2extxyz():
+    _write_pq_xyz("input.xyz")
+
+    traj2extxyz(["input.xyz"], output="output.extxyz")
+
+    _assert_extxyz_output("output.extxyz")
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_main():
+    _write_pq_xyz("input.xyz")
+
+    main_traj2extxyz()
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_pqanalysis_main():
+    _write_pq_xyz("input.xyz")
+
+    main_pqanalysis_traj2extxyz()
+
+
+@mock.patch(
+    "argparse.ArgumentParser.parse_args",
+    return_value=ArgparseNamespace(
+        trajectory_file=["input.xyz"],
+        output="output.extxyz",
+        engine="PQ",
+        mode="w",
+        log_file=None,
+        logging_level="INFO",
+    )
+)
+def main_traj2extxyz(mock_args):
+    assert Traj2ExtXYZCLI.program_name() == "traj2extxyz"
+
+    main()
+
+    _assert_extxyz_output("output.extxyz")
+
+
+@mock.patch(
+    "argparse.ArgumentParser.parse_args",
+    return_value=ArgparseNamespace(
+        cli_command="traj2extxyz",
+        trajectory_file=["input.xyz"],
+        output="output.extxyz",
+        engine="PQ",
+        mode="w",
+        log_file=None,
+        logging_level="INFO",
+    )
+)
+def main_pqanalysis_traj2extxyz(mock_args):
+    pqanalysis_main()
+
+    _assert_extxyz_output("output.extxyz")

--- a/tests/io/test_trajectoryWriter.py
+++ b/tests/io/test_trajectoryWriter.py
@@ -4,7 +4,12 @@ import numpy as np
 
 from . import pytestmark
 
-from PQAnalysis.io import TrajectoryWriter, write_trajectory, FileWritingMode
+from PQAnalysis.io import (
+    TrajectoryWriter,
+    read_trajectory,
+    write_trajectory,
+    FileWritingMode,
+)
 from PQAnalysis.traj import Trajectory, TrajectoryFormat, MDEngineFormat
 from PQAnalysis.core import Cell, Atom
 from PQAnalysis.atomic_system import AtomicSystem
@@ -34,6 +39,54 @@ o     0.0000000000     0.0000000000     1.0000000000
 h     0.0000000000     0.0000000000     0.0000000000
 o     0.0000000000     0.0000000000     1.0000000000
 """
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_write_extxyz_roundtrip():
+    atoms = [Atom("h"), Atom("o")]
+    frame = AtomicSystem(
+        atoms=atoms,
+        pos=np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        vel=np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
+        forces=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        charges=np.array([-0.1, -0.2]),
+        energy=-1.5,
+        virial=np.diag([1.0, 2.0, 3.0]),
+        stress=np.diag([4.0, 5.0, 6.0]),
+        cell=Cell(10.0, 11.0, 12.0, 80.0, 85.0, 95.0),
+    )
+
+    write_trajectory(
+        Trajectory([frame]),
+        filename="output.extxyz",
+        traj_type="extxyz",
+    )
+
+    with open("output.extxyz", "r", encoding="utf-8") as file:
+        lines = file.read().splitlines()
+
+    assert lines[0] == "2"
+    assert "Lattice=" in lines[1]
+    assert (
+        'Properties="species:S:1:pos:R:3:vel:R:3:forces:R:3:charge:R:1"'
+        in lines[1]
+    )
+    assert "energy=-1.5000000000" in lines[1]
+    assert "virial=" in lines[1]
+    assert "stress=" in lines[1]
+
+    trajectory = read_trajectory("output.extxyz", traj_format="extxyz")
+    output_frame = trajectory[0]
+
+    assert output_frame.atoms == atoms
+    assert np.allclose(output_frame.pos, frame.pos)
+    assert np.allclose(output_frame.vel, frame.vel)
+    assert np.allclose(output_frame.forces, frame.forces)
+    assert np.allclose(output_frame.charges, frame.charges)
+    assert output_frame.energy == frame.energy
+    assert np.allclose(output_frame.virial, frame.virial)
+    assert np.allclose(output_frame.stress, frame.stress)
+    assert output_frame.cell == frame.cell
 
 
 
@@ -75,6 +128,11 @@ class TestTrajectoryWriter:
         writer._write_header(1)
         captured = capsys.readouterr()
         assert captured.out == "1\n"
+
+        writer.format = MDEngineFormat.QMCFC
+        writer._write_header(1)
+        captured = capsys.readouterr()
+        assert captured.out == "2\n"
 
     def test__write_comment(self, capsys):
 


### PR DESCRIPTION
Resolves #121.

Adds extxyz writing support and a traj2extxyz CLI for converting PQ xyz trajectories. The tests cover PQAnalysis round-trips and ASE reading the generated file.