### PR TITLE
fix: preserve qmcfc input format

### DIFF
--- a/PQAnalysis/io/api.py
+++ b/PQAnalysis/io/api.py
@@ -58,6 +58,6 @@ def continue_input_file(
             exception=PQNotImplementedError
         )
 
-    reader = Reader(input_file)
+    reader = Reader(input_file, input_format)
     reader.read()
     reader.continue_input_file(n)

--- a/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
+++ b/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
@@ -8,7 +8,7 @@ import re
 from PQAnalysis.types import PositiveInt
 from PQAnalysis.io.input_file_reader.formats import InputFileFormat
 from PQAnalysis.io.input_file_reader.input_file_parser import InputFileParser
-from PQAnalysis.exceptions import PQValueError
+from PQAnalysis.exceptions import PQNotImplementedError, PQValueError
 from PQAnalysis.utils.custom_logging import setup_logger
 from PQAnalysis import __package_name__
 
@@ -30,17 +30,23 @@ class PQInputFileReader(_OutputFileMixin):
     logger = logging.getLogger(__package_name__).getChild(__qualname__)
     logger = setup_logger(logger)
 
-    def __init__(self, filename: str):
+    def __init__(
+        self,
+        filename: str,
+        input_format: InputFileFormat | str = InputFileFormat.PQ
+    ):
         """
         Initialize the PQ_InputFileReader class.
 
-        self.format is set to InputFileFormat.PQ.
+        self.format is set to a QMCF input format.
         A parser is created using the InputFileParser class.
 
         Parameters
         ----------
         filename : str
             filename of the input file
+        input_format : InputFileFormat | str, optional
+            the format of the input file, by default InputFileFormat.PQ
         """
 
         ########################
@@ -53,7 +59,17 @@ class PQInputFileReader(_OutputFileMixin):
         self.start_n = None
         self.actual_n = None
 
-        self.format = InputFileFormat.PQ
+        self.format = InputFileFormat(input_format)
+
+        if not InputFileFormat.is_qmcf_type(self.format):
+            self.logger.error(
+                (
+                    f"Format {self.format} not implemented "
+                    "for PQ input file reading."
+                ),
+                exception=PQNotImplementedError
+            )
+
         self.filename = filename
         self.parser = InputFileParser(self.filename, self.format)
 

--- a/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
+++ b/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
@@ -1,13 +1,15 @@
 import pytest
 
 from filecmp import cmp as filecmp
+from unittest.mock import patch
 
 from ... import pytestmark
 
+from PQAnalysis.io.api import continue_input_file
 from PQAnalysis.io.input_file_reader.pq.pq_input_file_reader import _increase_digit_string, _get_digit_string_from_filename
 from PQAnalysis.io.input_file_reader import PQInputFileReader as InputFileReader
 from PQAnalysis.io.input_file_reader.formats import InputFileFormat
-from PQAnalysis.exceptions import PQValueError
+from PQAnalysis.exceptions import PQNotImplementedError, PQValueError
 
 
 
@@ -74,6 +76,72 @@ class TestPQ_inputFileReader:
         assert input_file_reader.format == InputFileFormat("PQ")
         assert input_file_reader.parser.filename == "run-08.in"
         assert input_file_reader.parser.input_format == InputFileFormat("PQ")
+
+        input_file_reader = InputFileReader("run-08.in", "qmcfc")
+
+        assert input_file_reader.filename == "run-08.in"
+        assert input_file_reader.format == InputFileFormat.QMCFC
+        assert input_file_reader.parser.filename == "run-08.in"
+        assert input_file_reader.parser.input_format == InputFileFormat.QMCFC
+
+        with pytest.raises(PQNotImplementedError) as exception:
+            InputFileReader("run-08.in", "pqanalysis")
+        assert str(exception.value) == (
+            "Format InputFileFormat.PQANALYSIS not implemented "
+            "for PQ input file reading."
+        )
+
+    @pytest.mark.parametrize(
+        "example_dir",
+        ["inputFileReader/PQ_input/"],
+        indirect=False
+    )
+    def test_continue_input_file_passes_input_format(self, test_with_data_dir):
+        with patch("PQAnalysis.io.api.Reader") as reader_class:
+            reader = reader_class.return_value
+
+            continue_input_file("run-08.in", 1, "qmcfc")
+
+        reader_class.assert_called_once_with(
+            "run-08.in",
+            InputFileFormat.QMCFC
+        )
+        reader.read.assert_called_once_with()
+        reader.continue_input_file.assert_called_once_with(1)
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_qmcfc_input_file(self):
+        with open("run-1.in", "w", encoding="utf-8") as file:
+            file.write(
+                "keyword_set = qmcfc;\n"
+                "jobtype = mm-md;\n"
+                "force-field = on;\n"
+                "cell-list = on; cell-number = 10;\n"
+                "start_file = h2o-qmcf.rst;\n"
+                "output_file = qmcfc-1.out;\n"
+                "info_file = qmcfc-1.info;\n"
+                "energy_file = qmcfc-1.en;\n"
+                "traj_file = qmcfc-1.xyz;\n"
+                "vel_file = qmcfc-1.vel;\n"
+                "restart_file = qmcfc-1.rst;\n"
+            )
+
+        continue_input_file("run-1.in", 1, "qmcfc")
+
+        with open("run-2.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "keyword_set = qmcfc;\n"
+                "jobtype = mm-md;\n"
+                "force-field = on;\n"
+                "cell-list = on; cell-number = 10;\n"
+                "start_file = qmcfc-1.rst;\n"
+                "output_file = qmcfc-2.out;\n"
+                "info_file = qmcfc-2.info;\n"
+                "energy_file = qmcfc-2.en;\n"
+                "traj_file = qmcfc-2.xyz;\n"
+                "vel_file = qmcfc-2.vel;\n"
+                "restart_file = qmcfc-2.rst;\n"
+            )
 
     @pytest.mark.parametrize(
         "example_dir",


### PR DESCRIPTION
Resolves #10.

- Pass QMCFC input format through continue_input_file
- Allow PQInputFileReader to initialize with QMCFC
- Add regression coverage