### PR TITLE
feat: add extxyz output profiles

### DIFF
--- a/PQAnalysis/cli/traj2extxyz.py
+++ b/PQAnalysis/cli/traj2extxyz.py
@@ -8,6 +8,7 @@ Command Line Tool for Converting PQ Trajectory Files to Extended XYZ
 
 from PQAnalysis.config import code_base_url
 from PQAnalysis.io import traj2extxyz
+from PQAnalysis.io.formats import ExtXYZProfile
 from ._argument_parser import _ArgumentParser
 from ._cli_base import CLIBase
 
@@ -64,6 +65,17 @@ class Traj2ExtXYZCLI(CLIBase):
 
         parser.parse_engine()
         parser.parse_mode()
+        parser.add_argument(
+            "--extxyz-profile",
+            type=str,
+            choices=ExtXYZProfile.values(),
+            default=ExtXYZProfile.ASE.value,
+            help=(
+                "The extended xyz unit convention. Use 'ase' for eV-based "
+                "external tooling units, 'nep' for GPUMD NEP training data, "
+                "or 'pq' for native PQ units."
+            ),
+        )
 
     @classmethod
     def run(cls, args) -> None:
@@ -80,6 +92,7 @@ class Traj2ExtXYZCLI(CLIBase):
             args.output,
             args.mode,
             args.engine,
+            args.extxyz_profile,
         )
 
 

--- a/PQAnalysis/io/__init__.py
+++ b/PQAnalysis/io/__init__.py
@@ -4,7 +4,7 @@ and output of molecular dynamics simulations.
 """
 
 # import the formats from the formats module
-from .formats import BoxFileFormat, FileWritingMode, OutputFileFormat
+from .formats import BoxFileFormat, ExtXYZProfile, FileWritingMode, OutputFileFormat
 
 # import the classes from the base module
 from .base import BaseReader, BaseWriter

--- a/PQAnalysis/io/conversion_api.py
+++ b/PQAnalysis/io/conversion_api.py
@@ -9,7 +9,7 @@ from beartype.typing import List
 from PQAnalysis.core import Atoms, Cell, Residue, Residues
 from PQAnalysis.topology import Topology
 from PQAnalysis.traj import MDEngineFormat
-from PQAnalysis.io.formats import FileWritingMode
+from PQAnalysis.io.formats import ExtXYZProfile, FileWritingMode
 from PQAnalysis.type_checking import runtime_type_checking
 
 from .moldescriptor_reader import MoldescriptorReader
@@ -380,6 +380,7 @@ def traj2extxyz(
     output: str | None = None,
     mode: FileWritingMode | str = "w",
     md_format: MDEngineFormat | str = MDEngineFormat.PQ,
+    extxyz_profile: ExtXYZProfile | str = ExtXYZProfile.ASE,
 ) -> None:
     """
     Converts one or more PQ xyz trajectory files to extended xyz format and
@@ -398,9 +399,16 @@ def traj2extxyz(
         - "o": overwrite
     md_format : MDEngineFormat | str, optional
         The format of the input trajectory. The default is MDEngineFormat.PQ.
+    extxyz_profile : ExtXYZProfile | str, optional
+        The unit convention for the extended xyz output. The default is
+        ExtXYZProfile.ASE.
     """
 
-    writer = TrajectoryWriter(filename=output, mode=mode)
+    writer = TrajectoryWriter(
+        filename=output,
+        mode=mode,
+        extxyz_profile=extxyz_profile,
+    )
 
     for filename in trajectory_files:
         reader = TrajectoryReader(

--- a/PQAnalysis/io/exceptions.py
+++ b/PQAnalysis/io/exceptions.py
@@ -51,3 +51,11 @@ class OutputFileFormatError(BaseEnumFormatError):
     """
     Exception raised if the given enum is not valid
     """
+
+
+
+class ExtXYZProfileError(BaseEnumFormatError):
+
+    """
+    Exception raised if the given enum is not valid
+    """

--- a/PQAnalysis/io/formats.py
+++ b/PQAnalysis/io/formats.py
@@ -10,7 +10,10 @@ from PQAnalysis.utils.custom_logging import setup_logger
 from PQAnalysis import __package_name__
 
 from .exceptions import (
-    BoxFileFormatError, FileWritingModeError, OutputFileFormatError
+    BoxFileFormatError,
+    ExtXYZProfileError,
+    FileWritingModeError,
+    OutputFileFormatError,
 )
 
 logger = logging.getLogger(__package_name__).getChild("OutputFileFormat")
@@ -249,6 +252,41 @@ class OutputFileFormat(BaseEnumFormat):
             True if the enumeration is equal to the other object, False otherwise.
         """
         return super().__eq__(other) or self.value == str(other)
+
+
+
+class ExtXYZProfile(BaseEnumFormat):
+
+    """
+    An enumeration of supported extended xyz unit conventions.
+    """
+
+    #: ASE/libAtoms-compatible units: eV, eV/Angstrom, eV/Angstrom^3.
+    ASE = "ase"
+
+    #: PQ native units: kcal/mol, kcal/(mol Angstrom), kcal/(mol Angstrom^3).
+    PQ = "pq"
+
+    #: GPUMD NEP training data convention.
+    NEP = "nep"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Any:  # pylint: disable=arguments-differ
+        """
+        This method returns the missing value of the enumeration.
+
+        Parameters
+        ----------
+        value : object
+            The value to be converted to the enumeration.
+
+        Returns
+        -------
+        Any
+            The value to return.
+        """
+
+        return super()._missing_(value, ExtXYZProfileError)
 
 
 

--- a/PQAnalysis/io/traj_file/frame_reader.py
+++ b/PQAnalysis/io/traj_file/frame_reader.py
@@ -811,7 +811,7 @@ class ExtXYZFrameReader(BaseFrameReader):
         try:
             return np.array(
                 [float(value) for value in metadata[key].split()]
-            ).reshape((3, 3))
+            ).reshape((3, 3), order="F")
         except ValueError:
             self.logger.error(
                 f"Invalid {key} metadata in extended xyz frame.",

--- a/PQAnalysis/io/traj_file/trajectory_writer.py
+++ b/PQAnalysis/io/traj_file/trajectory_writer.py
@@ -2,15 +2,18 @@
 A module containing the TrajectoryWriter class and its associated methods.
 """
 
+import numpy as np
+
 from beartype.typing import List
 
 from PQAnalysis.io.base import BaseWriter
-from PQAnalysis.io.formats import FileWritingMode
+from PQAnalysis.io.formats import ExtXYZProfile, FileWritingMode
 from PQAnalysis.traj import Trajectory, TrajectoryFormat, MDEngineFormat
 from PQAnalysis.core import Cell, Atom
 from PQAnalysis.types import Np2DNumberArray, Np1DNumberArray
 from PQAnalysis.atomic_system import AtomicSystem
 from PQAnalysis.type_checking import runtime_type_checking, runtime_type_checking_setter
+from PQAnalysis.utils.units import eV, kcal_per_mol
 
 
 
@@ -28,7 +31,8 @@ class TrajectoryWriter(BaseWriter):
         self,
         filename: str | None = None,
         engine_format: MDEngineFormat | str = MDEngineFormat.PQ,
-        mode: str | FileWritingMode = 'w'
+        mode: str | FileWritingMode = 'w',
+        extxyz_profile: ExtXYZProfile | str = ExtXYZProfile.PQ,
     ) -> None:
         """
         Parameters
@@ -40,11 +44,15 @@ class TrajectoryWriter(BaseWriter):
         mode : str, optional
             The mode of the file. Either 'w' for write, 
             'a' for append or 'o' for overwrite. The default is 'w'.
+        extxyz_profile : ExtXYZProfile | str, optional
+            The unit convention for extended xyz output. The default is
+            ExtXYZProfile.PQ.
         """
 
         super().__init__(filename, FileWritingMode(mode))
 
         self.format = MDEngineFormat(engine_format)
+        self.extxyz_profile = ExtXYZProfile(extxyz_profile)
 
     @runtime_type_checking
     def write(
@@ -261,24 +269,30 @@ class TrajectoryWriter(BaseWriter):
         metadata = []
         if frame.cell != Cell():
             metadata.append(
-                f'Lattice="{self._format_extxyz_values(frame.cell.box_matrix.T)}"'
+                (
+                    f'{self._extxyz_lattice_key()}="'
+                    f'{self._format_extxyz_lattice(frame.cell.box_matrix)}"'
+                )
             )
 
         metadata.append(
-            f'Properties="{self._extxyz_properties(frame)}"'
+            f'{self._extxyz_properties_key()}="{self._extxyz_properties(frame)}"'
         )
 
         if frame.has_energy:
-            metadata.append(f"energy={self._format_extxyz_value(frame.energy)}")
+            energy = self._convert_extxyz_energy_like(frame.energy)
+            metadata.append(f"energy={self._format_extxyz_value(energy)}")
 
         if frame.has_virial:
+            virial = self._convert_extxyz_energy_like(frame.virial)
             metadata.append(
-                f'virial="{self._format_extxyz_values(frame.virial)}"'
+                f'virial="{self._format_extxyz_matrix(virial)}"'
             )
 
         if frame.has_stress:
+            stress = self._convert_extxyz_energy_like(frame.stress)
             metadata.append(
-                f'stress="{self._format_extxyz_values(frame.stress)}"'
+                f'stress="{self._format_extxyz_matrix(stress)}"'
             )
 
         print(" ".join(metadata), file=self.file)
@@ -310,7 +324,7 @@ class TrajectoryWriter(BaseWriter):
             The frame to write.
         """
         for i, atom in enumerate(frame.atoms):
-            values = [atom.name]
+            values = [self._extxyz_atom_label(atom)]
             values.extend(self._format_extxyz_value(value) for value in frame.pos[i])
 
             if frame.has_vel:
@@ -319,8 +333,9 @@ class TrajectoryWriter(BaseWriter):
                 )
 
             if frame.has_forces:
+                forces = self._convert_extxyz_energy_like(frame.forces)
                 values.extend(
-                    self._format_extxyz_value(value) for value in frame.forces[i]
+                    self._format_extxyz_value(value) for value in forces[i]
                 )
 
             if frame.has_charges:
@@ -328,14 +343,67 @@ class TrajectoryWriter(BaseWriter):
 
             print(" ".join(values), file=self.file)
 
-    def _format_extxyz_values(self, values: Np2DNumberArray) -> str:
+    def _format_extxyz_matrix(self, values: Np2DNumberArray) -> str:
         """
-        Formats a numeric array as a flat extended xyz metadata value.
+        Formats a 3x3 extended xyz metadata matrix.
+        """
+        order = "C" if self._is_gpumd_extxyz_profile() else "F"
+
+        return " ".join(
+            self._format_extxyz_value(value)
+            for value in np.asarray(values).flatten(order=order)
+        )
+
+    def _format_extxyz_lattice(self, values: Np2DNumberArray) -> str:
+        """
+        Formats extended xyz lattice vectors as ax ay az bx by bz cx cy cz.
         """
         return " ".join(
             self._format_extxyz_value(value)
-            for value in values.flatten()
+            for value in np.asarray(values).flatten(order="F")
         )
+
+    def _convert_extxyz_energy_like(self, values):
+        """
+        Converts PQ energy-like units to the configured extended xyz profile.
+        """
+        if self.extxyz_profile != ExtXYZProfile.PQ:
+            return values * eV / kcal_per_mol
+
+        return values
+
+    def _extxyz_lattice_key(self) -> str:
+        """
+        Returns the lattice metadata key for the configured extxyz profile.
+        """
+        if self._is_gpumd_extxyz_profile():
+            return "lattice"
+
+        return "Lattice"
+
+    def _extxyz_properties_key(self) -> str:
+        """
+        Returns the properties metadata key for the configured extxyz profile.
+        """
+        if self._is_gpumd_extxyz_profile():
+            return "properties"
+
+        return "Properties"
+
+    def _is_gpumd_extxyz_profile(self) -> bool:
+        """
+        Returns whether the configured extxyz profile targets GPUMD NEP.
+        """
+        return self.extxyz_profile == ExtXYZProfile.NEP
+
+    def _extxyz_atom_label(self, atom: Atom) -> str:
+        """
+        Returns the atom label for the configured extxyz profile.
+        """
+        if self._is_gpumd_extxyz_profile() and atom.symbol is not None:
+            return atom.symbol[0].upper() + atom.symbol[1:]
+
+        return atom.name
 
     def _format_extxyz_value(self, value) -> str:
         """
@@ -381,3 +449,13 @@ class TrajectoryWriter(BaseWriter):
     @runtime_type_checking_setter
     def type(self, traj_type: TrajectoryFormat | str) -> None:
         self._type = TrajectoryFormat(traj_type)
+
+    @property
+    def extxyz_profile(self) -> ExtXYZProfile:
+        """ExtXYZProfile: The unit convention for extended xyz output."""
+        return self._extxyz_profile
+
+    @extxyz_profile.setter
+    @runtime_type_checking_setter
+    def extxyz_profile(self, extxyz_profile: ExtXYZProfile | str) -> None:
+        self._extxyz_profile = ExtXYZProfile(extxyz_profile)

--- a/tests/cli/test_traj2extxyz.py
+++ b/tests/cli/test_traj2extxyz.py
@@ -66,6 +66,27 @@ def test_pqanalysis_main():
     main_pqanalysis_traj2extxyz()
 
 
+def test_run_passes_extxyz_profile():
+    args = ArgparseNamespace(
+        trajectory_file=["input.xyz"],
+        output="output.extxyz",
+        engine="PQ",
+        mode="w",
+        extxyz_profile="pq",
+    )
+
+    with mock.patch("PQAnalysis.cli.traj2extxyz.traj2extxyz") as convert:
+        Traj2ExtXYZCLI.run(args)
+
+    convert.assert_called_once_with(
+        ["input.xyz"],
+        "output.extxyz",
+        "w",
+        "PQ",
+        "pq",
+    )
+
+
 @mock.patch(
     "argparse.ArgumentParser.parse_args",
     return_value=ArgparseNamespace(
@@ -73,6 +94,7 @@ def test_pqanalysis_main():
         output="output.extxyz",
         engine="PQ",
         mode="w",
+        extxyz_profile="ase",
         log_file=None,
         logging_level="INFO",
     )
@@ -93,6 +115,7 @@ def main_traj2extxyz(mock_args):
         output="output.extxyz",
         engine="PQ",
         mode="w",
+        extxyz_profile="ase",
         log_file=None,
         logging_level="INFO",
     )

--- a/tests/io/test_frameReader.py
+++ b/tests/io/test_frameReader.py
@@ -197,6 +197,28 @@ def test_extxyz_frame_reader_reads_properties_and_metadata():
     assert frame.cell == Cell(10.0, 20.0, 30.0)
 
 
+def test_extxyz_frame_reader_reads_special_matrices_in_column_major_order():
+    reader = frame_reader.ExtXYZFrameReader()
+    frame_string = (
+        '1\n'
+        'Properties=species:S:1:pos:R:3 '
+        'virial="1 4 7 2 5 8 3 6 9" '
+        'stress="9 6 3 8 5 2 7 4 1"\n'
+        'H 0 0 0'
+    )
+
+    frame = reader.read(frame_string)
+
+    assert np.allclose(
+        frame.virial,
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    )
+    assert np.allclose(
+        frame.stress,
+        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    )
+
+
 def test_extxyz_frame_reader_reads_nep_writer_style_header():
     reader = frame_reader.ExtXYZFrameReader()
     frame_string = (

--- a/tests/io/test_trajectoryWriter.py
+++ b/tests/io/test_trajectoryWriter.py
@@ -5,6 +5,7 @@ import numpy as np
 from . import pytestmark
 
 from PQAnalysis.io import (
+    ExtXYZProfile,
     TrajectoryWriter,
     read_trajectory,
     write_trajectory,
@@ -12,8 +13,10 @@ from PQAnalysis.io import (
 )
 from PQAnalysis.traj import Trajectory, TrajectoryFormat, MDEngineFormat
 from PQAnalysis.core import Cell, Atom
+from PQAnalysis.io.exceptions import ExtXYZProfileError
 from PQAnalysis.atomic_system import AtomicSystem
 from PQAnalysis.traj.exceptions import MDEngineFormatError
+from PQAnalysis.utils.units import eV, kcal_per_mol
 
 
 
@@ -44,6 +47,8 @@ o     0.0000000000     0.0000000000     1.0000000000
 @pytest.mark.usefixtures("tmpdir")
 def test_write_extxyz_roundtrip():
     atoms = [Atom("h"), Atom("o")]
+    virial = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    stress = np.array([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]])
     frame = AtomicSystem(
         atoms=atoms,
         pos=np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
@@ -51,8 +56,8 @@ def test_write_extxyz_roundtrip():
         forces=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
         charges=np.array([-0.1, -0.2]),
         energy=-1.5,
-        virial=np.diag([1.0, 2.0, 3.0]),
-        stress=np.diag([4.0, 5.0, 6.0]),
+        virial=virial,
+        stress=stress,
         cell=Cell(10.0, 11.0, 12.0, 80.0, 85.0, 95.0),
     )
 
@@ -72,8 +77,8 @@ def test_write_extxyz_roundtrip():
         in lines[1]
     )
     assert "energy=-1.5000000000" in lines[1]
-    assert "virial=" in lines[1]
-    assert "stress=" in lines[1]
+    assert 'virial="1.0000000000 4.0000000000 7.0000000000' in lines[1]
+    assert 'stress="9.0000000000 6.0000000000 3.0000000000' in lines[1]
 
     trajectory = read_trajectory("output.extxyz", traj_format="extxyz")
     output_frame = trajectory[0]
@@ -87,6 +92,91 @@ def test_write_extxyz_roundtrip():
     assert np.allclose(output_frame.virial, frame.virial)
     assert np.allclose(output_frame.stress, frame.stress)
     assert output_frame.cell == frame.cell
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_write_extxyz_ase_profile_converts_energy_like_units():
+    from ase.io import read as ase_read
+
+    atoms = [Atom("h"), Atom("o")]
+    frame = AtomicSystem(
+        atoms=atoms,
+        pos=np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        forces=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        energy=-1.5,
+        virial=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        ),
+        stress=np.array(
+            [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]]
+        ),
+        cell=Cell(10.0, 11.0, 12.0),
+    )
+    conversion_factor = eV / kcal_per_mol
+
+    writer = TrajectoryWriter("ase.extxyz", extxyz_profile=ExtXYZProfile.ASE)
+    writer.write(frame, traj_type="extxyz")
+
+    with open("ase.extxyz", "r", encoding="utf-8") as file:
+        lines = file.read().splitlines()
+
+    assert f"energy={-1.5 * conversion_factor:.10f}" in lines[1]
+    assert f"{1.0 * conversion_factor:.10f}" in lines[2]
+    assert f"{9.0 * conversion_factor:.10f}" in lines[1]
+
+    ase_frame = ase_read("ase.extxyz", index=0)
+    assert np.isclose(ase_frame.calc.results["energy"], -1.5 * conversion_factor)
+    assert np.allclose(
+        ase_frame.calc.results["forces"],
+        frame.forces * conversion_factor,
+    )
+
+
+@pytest.mark.usefixtures("tmpdir")
+def test_write_extxyz_nep_profile_uses_gpumd_convention():
+    atoms = [Atom("h"), Atom("o")]
+    frame = AtomicSystem(
+        atoms=atoms,
+        pos=np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        forces=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        energy=-1.5,
+        virial=np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        ),
+        stress=np.array(
+            [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]]
+        ),
+        cell=Cell(10.0, 11.0, 12.0),
+    )
+    conversion_factor = eV / kcal_per_mol
+
+    writer = TrajectoryWriter("nep.extxyz", extxyz_profile=ExtXYZProfile.NEP)
+    writer.write(frame, traj_type="extxyz")
+
+    with open("nep.extxyz", "r", encoding="utf-8") as file:
+        lines = file.read().splitlines()
+
+    assert lines[1].startswith('lattice="10.0000000000 0.0000000000')
+    assert 'properties="species:S:1:pos:R:3:forces:R:3"' in lines[1]
+    assert "Lattice=" not in lines[1]
+    assert "Properties=" not in lines[1]
+    assert f"energy={-1.5 * conversion_factor:.10f}" in lines[1]
+    assert (
+        f'virial="{1.0 * conversion_factor:.10f} '
+        f"{2.0 * conversion_factor:.10f} "
+        f"{3.0 * conversion_factor:.10f}"
+    ) in lines[1]
+    assert (
+        f'stress="{9.0 * conversion_factor:.10f} '
+        f"{8.0 * conversion_factor:.10f} "
+        f"{7.0 * conversion_factor:.10f}"
+    ) in lines[1]
+    assert (
+        f"H 0.0000000000 0.0000000000 0.0000000000 "
+        f"{1.0 * conversion_factor:.10f} "
+        f"{2.0 * conversion_factor:.10f} "
+        f"{3.0 * conversion_factor:.10f}"
+    ) == lines[2]
 
 
 
@@ -109,12 +199,26 @@ class TestTrajectoryWriter:
         assert writer.filename is None
         assert writer.mode == FileWritingMode.WRITE
         assert writer.format == MDEngineFormat.PQ
+        assert writer.extxyz_profile == ExtXYZProfile.PQ
 
         writer = TrajectoryWriter(engine_format="qmcfc")
         assert writer.format == MDEngineFormat.QMCFC
 
         writer = TrajectoryWriter(engine_format="PQ")
         assert writer.format == MDEngineFormat.PQ
+
+        writer.extxyz_profile = "ASE"
+        assert writer.extxyz_profile == ExtXYZProfile.ASE
+
+        with pytest.raises(ExtXYZProfileError) as exception:
+            TrajectoryWriter(extxyz_profile="notAProfile")
+        assert str(exception.value) == (
+            "\n"
+            "'notaprofile' is not a valid ExtXYZProfile.\n"
+            f"Possible values are: {ExtXYZProfile.member_repr()} "
+            "or their case insensitive string representation: "
+            f"{ExtXYZProfile.value_repr()}"
+        )
 
     def test__write_header(self, capsys):
 


### PR DESCRIPTION
## Summary
- add ase, pq, and nep extxyz output profiles
- convert energy-like values for external profiles
- cover ASE and GPUMD NEP output behavior

## Tests
- PYTHONDONTWRITEBYTECODE=1 bash pytest.sh -q
- pylint PQAnalysis --exit-zero --persistent n