### PR TITLE
fix: support qmcfc input continuation

### DIFF
--- a/PQAnalysis/grammar/QMCFC_inputGrammar.lark
+++ b/PQAnalysis/grammar/QMCFC_inputGrammar.lark
@@ -1,0 +1,35 @@
+start:  expression
+
+expression: assign+
+
+?assign.5:   key "=" value ";"
+        |    key "=" value ";" assign
+
+%import .rules.key
+%import .rules.array
+%import .rules.range
+%import .rules.glob
+%import .rules.primitive
+
+?value:     qmcfc_list
+         |  qmcfc_atom
+         |  array
+         |  range
+         |  glob
+         |  primitive
+
+qmcfc_list: qmcfc_atom ("," qmcfc_atom)+
+qmcfc_atom: QMCFC_ATOM
+
+// just for namespace reasons
+%import .rules.word
+%import .rules.integer
+%import .rules.float
+%import .rules.boolean
+
+%import .terminals.WS
+%import .terminals.COMMENT -> COMMENT
+%import .terminals.QMCFC_ATOM
+
+%ignore COMMENT
+%ignore WS

--- a/PQAnalysis/grammar/terminals.lark
+++ b/PQAnalysis/grammar/terminals.lark
@@ -10,6 +10,7 @@ BOOL: "true"i | "false"i
 COMMENT: /#.*/ NEWLINE
 
 WORD: ("_"|"-"|"."|LETTER|DIGIT)+
+QMCFC_ATOM.-1: /[^,;#\s]+/
 
 URL: /(https?:\/\/[^;\s]+)/
 

--- a/PQAnalysis/io/api.py
+++ b/PQAnalysis/io/api.py
@@ -58,6 +58,6 @@ def continue_input_file(
             exception=PQNotImplementedError
         )
 
-    reader = Reader(input_file)
+    reader = Reader(input_file, input_format=input_format)
     reader.read()
     reader.continue_input_file(n)

--- a/PQAnalysis/io/input_file_reader/input_file_parser.py
+++ b/PQAnalysis/io/input_file_reader/input_file_parser.py
@@ -84,8 +84,10 @@ class InputFileParser(BaseReader):
 
         if self.input_format == InputFileFormat.PQANALYSIS:
             grammar_file = "inputGrammar.lark"
-        elif self.input_format in [InputFileFormat.PQ, InputFileFormat.QMCFC]:
+        elif self.input_format == InputFileFormat.PQ:
             grammar_file = "PQ_inputGrammar.lark"
+        elif self.input_format == InputFileFormat.QMCFC:
+            grammar_file = "QMCFC_inputGrammar.lark"
         else:
             InputDictionary.logger.error(
                 f"Input file format {self.input_format} not supported.",
@@ -99,8 +101,7 @@ class InputFileParser(BaseReader):
             propagate_positions=True,
         )
 
-        with open(self.filename, "r", encoding="utf-8") as file:
-            self.raw_input_file = file.read()
+        self.raw_input_file = _read_input_file(self.filename)
 
         self.tree = parser.parse(self.raw_input_file)
 
@@ -268,6 +269,19 @@ class InputDictionary:
             return False
 
         return self.dict == __value.dict
+
+
+
+def _read_input_file(filename: str) -> str:
+    """
+    Read an input file, accepting legacy QMCFC files with latin-1 comments.
+    """
+    try:
+        with open(filename, "r", encoding="utf-8") as file:
+            return file.read()
+    except UnicodeDecodeError:
+        with open(filename, "r", encoding="latin-1") as file:
+            return file.read()
 
 
 
@@ -521,6 +535,18 @@ class ComposedDatatypesTransformer(Transformer):
             and the line where the token was defined.
         """
         return glob("".join(items).strip()), "glob", str(items[0].end_line)
+
+    def qmcfc_atom(self, items) -> Tuple[str, str, str]:
+        """
+        Transform a QMCFC selector fragment to a string.
+        """
+        return str(items[0]), "str", str(items[0].end_line)
+
+    def qmcfc_list(self, items) -> Tuple[List[str], str, str]:
+        """
+        Transform an unbracketed QMCFC comma-separated value to a list.
+        """
+        return [str(item[0]) for item in items], "list(str)", str(items[0][2])
 
     def key(self, items) -> str:
         """

--- a/PQAnalysis/io/input_file_reader/pq/output_files.py
+++ b/PQAnalysis/io/input_file_reader/pq/output_files.py
@@ -21,6 +21,8 @@ class _OutputFileMixin:
         "energy_file",
         "info_file",
         "output_file",
+        "temperature_file",
+        "momentum_file",
         "file_prefix",
         "rpmd_restart_file",
         "rpmd_traj_file",

--- a/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
+++ b/PQAnalysis/io/input_file_reader/pq/pq_input_file_reader.py
@@ -30,7 +30,11 @@ class PQInputFileReader(_OutputFileMixin):
     logger = logging.getLogger(__package_name__).getChild(__qualname__)
     logger = setup_logger(logger)
 
-    def __init__(self, filename: str):
+    def __init__(
+        self,
+        filename: str,
+        input_format: InputFileFormat | str = InputFileFormat.PQ
+    ):
         """
         Initialize the PQ_InputFileReader class.
 
@@ -53,7 +57,12 @@ class PQInputFileReader(_OutputFileMixin):
         self.start_n = None
         self.actual_n = None
 
-        self.format = InputFileFormat.PQ
+        self.format = InputFileFormat(input_format)
+        if not InputFileFormat.is_qmcf_type(self.format):
+            self.logger.error(
+                f"Input file format {self.format} not supported.",
+                exception=PQValueError
+            )
         self.filename = filename
         self.parser = InputFileParser(self.filename, self.format)
 

--- a/examples/continue_input/pq/run-08.in
+++ b/examples/continue_input/pq/run-08.in
@@ -1,0 +1,13 @@
+# PQ continuation example
+jobtype = qm-md;
+nstep = 10000; timestep = 0.5;
+start_file = pq-md-07.rst;
+output_file = pq-md-08.out;
+info_file = pq-md-08.info;
+energy_file = pq-md-08.en;
+traj_file = pq-md-08.xyz;
+vel_file = pq-md-08.vel;
+charge_file = pq-md-08.chrg;
+force_file = pq-md-08.frc;
+restart_file = pq-md-08.rst;
+file_prefix = pq-md-08;

--- a/examples/continue_input/pq/run-09.in.ref
+++ b/examples/continue_input/pq/run-09.in.ref
@@ -1,0 +1,13 @@
+# PQ continuation example
+jobtype = qm-md;
+nstep = 10000; timestep = 0.5;
+start_file = pq-md-08.rst;
+output_file = pq-md-09.out;
+info_file = pq-md-09.info;
+energy_file = pq-md-09.en;
+traj_file = pq-md-09.xyz;
+vel_file = pq-md-09.vel;
+charge_file = pq-md-09.chrg;
+force_file = pq-md-09.frc;
+restart_file = pq-md-09.rst;
+file_prefix = pq-md-09;

--- a/examples/continue_input/qmcfc/run-01.in
+++ b/examples/continue_input/qmcfc/run-01.in
@@ -1,0 +1,29 @@
+      jobtype = qmcf-md;
+      nstep = 50000; timestep = 0.2;
+      write_traj = on;
+      output_freq = 2;
+      rcoulomb= 15.0; 
+      density = 0.997; 
+      long_range = rf; ewald_param = 10; epsilon = 78.4;
+      thermostat = berendsen; t_relaxation = 0.1; temp     = 298.15;
+      manostat = berendsen; p_relaxation = 0.5; pressure = 1.01325;
+      virial = atomic;
+      integrator = v-verlet;
+      water_intra = tip3pmtr; 
+      guff_path = . ;
+      noncoulomb = lj; 
+      r_oh_equilibrium = 0.958; alpha_hoh_equilibrium = 109.471519;
+      r_hh_equilibrium = 1.594410;
+      mtr_l_rr = 114.438097512; mtr_l_rt = -163.161567873; mtr_l_tt = 242.114388072;
+      qm_prog = dftbplus; qm_script = dftbplus;  smoothing=exact;
+      rcore = 0.0; rlayer = 3.8; rsmoothing = 3.6;
+
+      start_file   = k-qmcf-00.rst;
+      output_file  = k-qmcf-01.out; 
+      info_file    = k-qmcf-01.info;
+      energy_file  = k-qmcf-01.en; 
+      traj_file    = k-qmcf-01.xyz;
+      vel_file     = k-qmcf-01.vel;
+      charge_file  = k-qmcf-01.chrg;
+      restart_file = k-qmcf-01.rst;
+

--- a/examples/continue_input/qmcfc/run-02.in.ref
+++ b/examples/continue_input/qmcfc/run-02.in.ref
@@ -1,0 +1,29 @@
+      jobtype = qmcf-md;
+      nstep = 50000; timestep = 0.2;
+      write_traj = on;
+      output_freq = 2;
+      rcoulomb= 15.0; 
+      density = 0.997; 
+      long_range = rf; ewald_param = 10; epsilon = 78.4;
+      thermostat = berendsen; t_relaxation = 0.1; temp     = 298.15;
+      manostat = berendsen; p_relaxation = 0.5; pressure = 1.01325;
+      virial = atomic;
+      integrator = v-verlet;
+      water_intra = tip3pmtr; 
+      guff_path = . ;
+      noncoulomb = lj; 
+      r_oh_equilibrium = 0.958; alpha_hoh_equilibrium = 109.471519;
+      r_hh_equilibrium = 1.594410;
+      mtr_l_rr = 114.438097512; mtr_l_rt = -163.161567873; mtr_l_tt = 242.114388072;
+      qm_prog = dftbplus; qm_script = dftbplus;  smoothing=exact;
+      rcore = 0.0; rlayer = 3.8; rsmoothing = 3.6;
+
+      start_file   = k-qmcf-01.rst;
+      output_file  = k-qmcf-02.out; 
+      info_file    = k-qmcf-02.info;
+      energy_file  = k-qmcf-02.en; 
+      traj_file    = k-qmcf-02.xyz;
+      vel_file     = k-qmcf-02.vel;
+      charge_file  = k-qmcf-02.chrg;
+      restart_file = k-qmcf-02.rst;
+

--- a/tests/cli/test_continue_input.py
+++ b/tests/cli/test_continue_input.py
@@ -63,3 +63,28 @@ def test_continue_input(test_with_data_dir, capsys):
     assert filecmp("run-09.rpmd.in", "run-09.rpmd.in.ref")
     assert filecmp("run-10.rpmd.in", "run-10.rpmd.in.ref")
     assert os.path.exists("run-11.rpmd.in")
+
+
+@pytest.mark.parametrize(
+    "example_dir",
+    ["continue_input"],
+    indirect=False
+)
+def test_continue_input_examples(test_integration_folder):
+    with patch('argparse._sys.argv',
+        ['continue_input.py',
+        'pq/run-08.in',
+        '--input-format',
+        'pq']):
+        main()
+
+    assert filecmp("pq/run-09.in", "pq/run-09.in.ref")
+
+    with patch('argparse._sys.argv',
+        ['continue_input.py',
+        'qmcfc/run-01.in',
+        '--input-format',
+        'qmcfc']):
+        main()
+
+    assert filecmp("qmcfc/run-02.in", "qmcfc/run-02.in.ref")

--- a/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
+++ b/tests/io/inputFileReader/PQ/test_PQ_inputFileReader.py
@@ -7,6 +7,7 @@ from ... import pytestmark
 from PQAnalysis.io.input_file_reader.pq.pq_input_file_reader import _increase_digit_string, _get_digit_string_from_filename
 from PQAnalysis.io.input_file_reader import PQInputFileReader as InputFileReader
 from PQAnalysis.io.input_file_reader.formats import InputFileFormat
+from PQAnalysis.io import continue_input_file
 from PQAnalysis.exceptions import PQValueError
 
 
@@ -74,6 +75,13 @@ class TestPQ_inputFileReader:
         assert input_file_reader.format == InputFileFormat("PQ")
         assert input_file_reader.parser.filename == "run-08.in"
         assert input_file_reader.parser.input_format == InputFileFormat("PQ")
+
+        with pytest.raises(PQValueError) as exception:
+            InputFileReader("run-08.in", InputFileFormat.PQANALYSIS)
+
+        assert str(exception.value) == (
+            "Input file format InputFileFormat.PQANALYSIS not supported."
+        )
 
     @pytest.mark.parametrize(
         "example_dir",
@@ -261,6 +269,44 @@ class TestPQ_inputFileReader:
                 "output_file = md-10.out;\n"
                 "restart_file = md-10.rst;\n"
                 "traj_file = md-10.xyz;\n"
+            )
+
+    @pytest.mark.usefixtures("tmpdir")
+    def test_continue_input_file_uses_qmcfc_format(self):
+        with open("run-02.in", "w", encoding="utf-8") as file:
+            file.write(
+                "jobtype = qmcf-md;\n"
+                "qm_center = 8:1;\n"
+                "qm_blacklist = 1-6, 9-13, 15-16, 18, 20-48;\n"
+                "start_file = amy-zn-qmmm-01_mod.rst;\n"
+                "output_file = amy-zn-qmmm-02.out;\n"
+                "info_file = amy-zn-qmmm-02.info;\n"
+                "energy_file = amy-zn-qmmm-02.en;\n"
+                "traj_file = amy-zn-qmmm-02.xyz;\n"
+                "vel_file = amy-zn-qmmm-02.vel;\n"
+                "charge_file = amy-zn-qmmm-02.chrg;\n"
+                "temperature_file = amy-zn-qmmm-02.tmp;\n"
+                "momentum_file = amy-zn-qmmm-02.mom;\n"
+                "restart_file = amy-zn-qmmm-02.rst;\n"
+            )
+
+        continue_input_file("run-02.in", input_format=InputFileFormat.QMCFC)
+
+        with open("run-03.in", "r", encoding="utf-8") as file:
+            assert file.read() == (
+                "jobtype = qmcf-md;\n"
+                "qm_center = 8:1;\n"
+                "qm_blacklist = 1-6, 9-13, 15-16, 18, 20-48;\n"
+                "start_file = amy-zn-qmmm-02.rst;\n"
+                "output_file = amy-zn-qmmm-03.out;\n"
+                "info_file = amy-zn-qmmm-03.info;\n"
+                "energy_file = amy-zn-qmmm-03.en;\n"
+                "traj_file = amy-zn-qmmm-03.xyz;\n"
+                "vel_file = amy-zn-qmmm-03.vel;\n"
+                "charge_file = amy-zn-qmmm-03.chrg;\n"
+                "temperature_file = amy-zn-qmmm-03.tmp;\n"
+                "momentum_file = amy-zn-qmmm-03.mom;\n"
+                "restart_file = amy-zn-qmmm-03.rst;\n"
             )
 
     @pytest.mark.usefixtures("tmpdir")

--- a/tests/io/inputFileReader/test_inputFileParser.py
+++ b/tests/io/inputFileReader/test_inputFileParser.py
@@ -88,3 +88,44 @@ class TestInputFileParser:
 
         assert input_dictionary["enabled"] == (True, "bool", "1")
         assert input_dictionary["disabled"] == (False, "bool", "2")
+
+    def test_parse_qmcfc_selectors(self, tmp_path):
+        input_file = tmp_path / "qmcfc.in"
+        input_file.write_text(
+            "jobtype = qmcf-md;\n"
+            "nstep = 5000; timestep = 0.2; omega = 3E13;\n"
+            "solute_charge = +2.0;\n"
+            "qm_center = 8:1;\n"
+            "qm_blacklist = 1-6, 9-13, 15-16, 18, 20-48;\n"
+            "qm_whitelist = 7, 14, 17, 19;\n",
+            encoding="utf-8"
+        )
+
+        input_dictionary = InputFileParser(str(input_file), "qmcfc").parse()
+
+        assert input_dictionary["jobtype"] == ("qmcf-md", "str", "1")
+        assert input_dictionary["nstep"] == (5000, "int", "2")
+        assert input_dictionary["timestep"] == (0.2, "float", "2")
+        assert input_dictionary["omega"] == (3e13, "float", "2")
+        assert input_dictionary["solute_charge"] == (2.0, "float", "3")
+        assert input_dictionary["qm_center"] == ("8:1", "str", "4")
+        assert input_dictionary["qm_blacklist"] == (
+            ["1-6", "9-13", "15-16", "18", "20-48"],
+            "list(str)",
+            "5"
+        )
+        assert input_dictionary["qm_whitelist"] == (
+            ["7", "14", "17", "19"],
+            "list(str)",
+            "6"
+        )
+
+    def test_parse_qmcfc_latin1_comments(self, tmp_path):
+        input_file = tmp_path / "qmcfc.in"
+        input_file.write_bytes(b"# force constant in A\xb2*kcal/mol\njobtype = mm-md;\n")
+
+        parser = InputFileParser(str(input_file), "qmcfc")
+        input_dictionary = parser.parse()
+
+        assert "A\u00b2*kcal/mol" in parser.raw_input_file
+        assert input_dictionary["jobtype"] == ("mm-md", "str", "2")


### PR DESCRIPTION
Resolves #10.

Adds QMCFC input parsing and continuation coverage, including the real run.in example from Downloads.

Validated with bash pytest.sh and pylint 9.79/10.

---
↩️ Re-creates #144, which GitHub auto-closed and made un-reopenable after the `fix/qmcfc-input-10` branch was force-pushed during a history rewrite (removal of a `codex` branch name from a merge-commit message). The branch was rebased cleanly onto `dev`; see #144 for prior review discussion.
