### PR TITLE
build: add conda-forge recipe

### DIFF
--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -1,0 +1,42 @@
+# conda-forge recipe
+
+Draft [conda-forge](https://conda-forge.org/) recipe for distributing PQAnalysis
+through the `conda-forge` channel. It is kept here for reference and
+maintenance; the recipe conda-forge actually builds lives in the `pqanalysis`
+*feedstock* created from
+[`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes).
+
+PQAnalysis ships a compiled Cython extension
+(`PQAnalysis/io/traj_file/process_lines.pyx`), so this is a per-platform
+(non-`noarch`) recipe: it needs a C compiler (`{{ compiler('c') }}` /
+`{{ stdlib('c') }}`) and `build.sh` / `bld.bat`. It requires Python `>=3.12`
+(`skip: true  # [py<312]`). All run dependencies (`numpy`, `scipy`, `beartype`,
+`multimethod`, `lark`, `tqdm`, `decorator`, `argcomplete`, `rich-argparse`) are
+already on conda-forge.
+
+## Before submitting
+
+- **Maintainer(s):** `extra.recipe-maintainers` lists `galjos`. Add any other
+  GitHub usernames who should co-maintain the feedstock.
+- **Version & hash** are pinned to the current PyPI release (1.3.0). To refresh
+  for a new release, bump `version` and replace `sha256` with the sdist hash:
+
+  ```bash
+  curl -sL https://pypi.org/pypi/PQAnalysis/json \
+    | python -c "import json,sys; d=json.load(sys.stdin); \
+        print(next(u['digests']['sha256'] for u in d['urls'] if u['packagetype']=='sdist'))"
+  ```
+
+  After the feedstock exists, conda-forge's `regro-cf-autotick-bot` opens
+  version-bump PRs automatically.
+
+## Local check (optional)
+
+With `conda-build` / `conda-smithy` installed:
+
+```bash
+conda smithy recipe-lint conda-recipes/pqanalysis
+conda build conda-recipes/pqanalysis -c conda-forge
+```
+
+See the conda-forge [contributing guide](https://conda-forge.org/docs/maintainer/adding_pkgs/).

--- a/conda-recipes/pqanalysis/bld.bat
+++ b/conda-recipes/pqanalysis/bld.bat
@@ -1,0 +1,4 @@
+set SETUPTOOLS_SCM_PRETEND_VERSION=%PKG_VERSION%
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/conda-recipes/pqanalysis/build.sh
+++ b/conda-recipes/pqanalysis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+
+# The PyPI sdist has no .git, so tell setuptools_scm the version explicitly.
+export SETUPTOOLS_SCM_PRETEND_VERSION="${PKG_VERSION}"
+
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/conda-recipes/pqanalysis/meta.yaml
+++ b/conda-recipes/pqanalysis/meta.yaml
@@ -1,0 +1,82 @@
+{% set name = "PQAnalysis" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 6b7ecd3aeb553c8c8cdc12805f991145e956690d73a7eddd4f71481c519ddc3e
+
+build:
+  number: 0
+  # Not noarch: PQAnalysis ships a compiled Cython extension
+  # (PQAnalysis/io/traj_file/*.pyx), so it is built per platform. pip enforces
+  # Requires-Python >=3.12, so skip the older interpreters in the build matrix.
+  skip: true  # [py<312]
+  entry_points:
+    - pqanalysis = PQAnalysis.cli.main:main
+    - traj2box = PQAnalysis.cli.traj2box:main
+    - traj2extxyz = PQAnalysis.cli.traj2extxyz:main
+    - traj2qmcfc = PQAnalysis.cli.traj2qmcfc:main
+    - rst2xyz = PQAnalysis.cli.rst2xyz:main
+    - xyz2rst = PQAnalysis.cli.xyz2rst:main
+    - continue_input = PQAnalysis.cli.continue_input:main
+    - rdf = PQAnalysis.cli.rdf:main
+    - add_molecules = PQAnalysis.cli.add_molecules:main
+    - activate_argcomplete = PQAnalysis.cli.activate_argcomplete:main
+    - build_nep_traj = PQAnalysis.cli.build_nep_traj:main
+    - xyz2gen = PQAnalysis.cli.xyz2gen:main
+    - gen2xyz = PQAnalysis.cli.gen2xyz:main
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools >=70
+    - setuptools_scm >=8
+    - wheel
+    - cython >=3
+    - numpy
+  run:
+    - python
+    - numpy
+    - scipy
+    - beartype
+    - multimethod
+    - lark
+    - tqdm
+    - decorator
+    - argcomplete
+    - rich-argparse
+
+test:
+  imports:
+    - PQAnalysis
+    - PQAnalysis.io
+    # the compiled Cython extension; import fails if the C build is broken
+    - PQAnalysis.io.traj_file.process_lines
+  commands:
+    - pip check
+    - pqanalysis --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/MolarVerse/PQAnalysis
+  license: MIT
+  license_file: LICENSE
+  summary: A Python package for the post-processing and analysis of molecular dynamics simulations.
+  description: |
+    PQAnalysis reads, writes, and analyses molecular dynamics trajectories and
+    related data (coordinates, restart files, cells), with command-line tools
+    for common trajectory conversions.
+  dev_url: https://github.com/MolarVerse/PQAnalysis
+
+extra:
+  recipe-maintainers:
+    - galjos


### PR DESCRIPTION
Adds a draft conda-forge recipe under `conda-recipes/pqanalysis/` for reference and maintenance, mirroring the setup in the [ThermoScreening](https://github.com/MolarVerse/ThermoScreening) repo.

PQAnalysis ships a compiled Cython extension (`PQAnalysis/io/traj_file/process_lines.pyx`), so this is a per-platform (non-`noarch`) recipe with `{{ compiler('c') }}` / `{{ stdlib('c') }}`, `build.sh` + `bld.bat`, and a `skip: true  # [py<312]`. All run dependencies are already on conda-forge.

Validated: passes `conda-smithy recipe-lint` and builds + tests locally on osx-arm64 for Python 3.12 and 3.13 (compiled-extension import + `pqanalysis --help` + `pip check`). Submitted to `conda-forge/staged-recipes` together with the ThermoScreening recipe.